### PR TITLE
fix: author photos and sharp image corners

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,20 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/great-canadian-builders",
+        destination: "/builders",
+        permanent: true,
+      },
+      {
+        source: "/great-canadian-builders/:slug",
+        destination: "/builders/:slug",
+        permanent: true,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@9.5.0",
   "scripts": {
     "dev": "next dev -p 5050",
+    "dev:remote": "YORK_FACTORY_API_URL=https://york-factory.eng.canadasbuilding.com/api/v1 next dev -p 5050",
     "build": "next build",
     "start": "next start -p 5050",
     "lint": "eslint && npm run lint:tokens",

--- a/src/app/builders/[slug]/page.tsx
+++ b/src/app/builders/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default async function BuilderPage({
 
         {builder.body && (
           <div
-            className="mt-6 prose prose-body"
+            className="mt-6 prose-bc"
             dangerouslySetInnerHTML={{ __html: builder.body }}
           />
         )}

--- a/src/app/builders/[slug]/page.tsx
+++ b/src/app/builders/[slug]/page.tsx
@@ -1,11 +1,8 @@
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
+import Image from "next/image";
 import Link from "next/link";
-import { builders, getBuilderBySlug } from "@/lib/builders";
-
-export function generateStaticParams() {
-  return builders.map((b) => ({ slug: b.slug }));
-}
+import { fetchBuilder, fetchBuilders } from "@/lib/api/builders";
 
 export async function generateMetadata({
   params,
@@ -13,19 +10,21 @@ export async function generateMetadata({
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> {
   const { slug } = await params;
-  const builder = getBuilderBySlug(slug);
-  if (!builder) return { title: "Builder Not Found | Build Canada" };
-
-  return {
-    title: `${builder.name}: ${builder.tagline}`,
-    description: builder.quote,
-    openGraph: {
-      title: `${builder.name}: ${builder.tagline} | Build Canada`,
-      description: builder.quote,
-      type: "article",
-      images: [{ url: builder.gif }],
-    },
-  };
+  try {
+    const builder = await fetchBuilder(slug);
+    return {
+      title: `${builder.name}: ${builder.tagline}`,
+      description: builder.quote ?? undefined,
+      openGraph: {
+        title: `${builder.name}: ${builder.tagline} | Build Canada`,
+        description: builder.quote ?? undefined,
+        type: "article",
+        images: builder.imageUrl ? [{ url: builder.imageUrl }] : undefined,
+      },
+    };
+  } catch {
+    return { title: "Builder Not Found | Build Canada" };
+  }
 }
 
 export default async function BuilderPage({
@@ -34,10 +33,12 @@ export default async function BuilderPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const builder = getBuilderBySlug(slug);
-  if (!builder) notFound();
-
-  const paragraphs = builder.story.split("\n\n");
+  let builder;
+  try {
+    builder = await fetchBuilder(slug);
+  } catch {
+    notFound();
+  }
 
   return (
     <div className="mx-[10px] my-[10px] border border-border-light bg-bg">
@@ -49,31 +50,42 @@ export default async function BuilderPage({
           &larr; Back to Great Canadian Builders
         </Link>
 
-        <div className="relative w-full h-[240px] md:h-[360px] mt-6 overflow-hidden bg-border-light">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src={builder.gif}
-            alt={`${builder.name} — ${builder.tagline}`}
-            className="w-full h-full object-cover"
-          />
-        </div>
+        {builder.imageUrl && (
+          <div className="relative w-full h-[240px] md:h-[360px] mt-6 overflow-hidden bg-border-light">
+            <Image
+              src={builder.imageUrl}
+              alt={`${builder.name} — ${builder.tagline}`}
+              fill
+              className="object-cover"
+              unoptimized
+              priority
+            />
+          </div>
+        )}
 
         <h1 className="type-title mt-6">{builder.name}</h1>
         <p className="type-body text-text-secondary mt-1">{builder.tagline}</p>
 
-        <blockquote className="border-l-2 border-border-light pl-4 my-6">
-          <p className="type-body italic text-text-secondary">
-            &ldquo;{builder.quote}&rdquo;
-          </p>
-        </blockquote>
-
-        <div className="mt-6 space-y-4">
-          {paragraphs.map((p, i) => (
-            <p key={i} className="type-body text-dark leading-relaxed">
-              {p}
+        {builder.quote && (
+          <blockquote className="border-l-2 border-border-light pl-4 my-6">
+            <p className="type-body italic text-text-secondary">
+              &ldquo;{builder.quote}&rdquo;
             </p>
-          ))}
-        </div>
+          </blockquote>
+        )}
+
+        {builder.body && (
+          <div
+            className="mt-6 prose prose-body"
+            dangerouslySetInnerHTML={{ __html: builder.body }}
+          />
+        )}
+
+        {builder.author && (
+          <p className="type-body-sm text-text-secondary mt-8">
+            Written by {builder.author}
+          </p>
+        )}
       </article>
     </div>
   );

--- a/src/app/builders/[slug]/page.tsx
+++ b/src/app/builders/[slug]/page.tsx
@@ -1,0 +1,80 @@
+import { notFound } from "next/navigation";
+import type { Metadata } from "next";
+import Link from "next/link";
+import { builders, getBuilderBySlug } from "@/lib/builders";
+
+export function generateStaticParams() {
+  return builders.map((b) => ({ slug: b.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const builder = getBuilderBySlug(slug);
+  if (!builder) return { title: "Builder Not Found | Build Canada" };
+
+  return {
+    title: `${builder.name}: ${builder.tagline}`,
+    description: builder.quote,
+    openGraph: {
+      title: `${builder.name}: ${builder.tagline} | Build Canada`,
+      description: builder.quote,
+      type: "article",
+      images: [{ url: builder.gif }],
+    },
+  };
+}
+
+export default async function BuilderPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+  const builder = getBuilderBySlug(slug);
+  if (!builder) notFound();
+
+  const paragraphs = builder.story.split("\n\n");
+
+  return (
+    <div className="mx-[10px] my-[10px] border border-border-light bg-bg">
+      <article className="animate-fade-in max-w-2xl mx-auto px-5 pt-[50px] pb-[60px]">
+        <Link
+          href="/builders"
+          className="type-label text-text-muted hover:text-dark transition-colors"
+        >
+          &larr; Back to Great Canadian Builders
+        </Link>
+
+        <div className="relative w-full h-[240px] md:h-[360px] mt-6 overflow-hidden bg-border-light">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={builder.gif}
+            alt={`${builder.name} — ${builder.tagline}`}
+            className="w-full h-full object-cover"
+          />
+        </div>
+
+        <h1 className="type-title mt-6">{builder.name}</h1>
+        <p className="type-body text-text-secondary mt-1">{builder.tagline}</p>
+
+        <blockquote className="border-l-2 border-border-light pl-4 my-6">
+          <p className="type-body italic text-text-secondary">
+            &ldquo;{builder.quote}&rdquo;
+          </p>
+        </blockquote>
+
+        <div className="mt-6 space-y-4">
+          {paragraphs.map((p, i) => (
+            <p key={i} className="type-body text-dark leading-relaxed">
+              {p}
+            </p>
+          ))}
+        </div>
+      </article>
+    </div>
+  );
+}

--- a/src/app/builders/page.tsx
+++ b/src/app/builders/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import Image from "next/image";
 import SectionLabel from "@/components/SectionLabel";
-import { builders } from "@/lib/builders";
+import { fetchBuilders } from "@/lib/api/builders";
 
 export const metadata: Metadata = {
   title: "Great Canadian Builders",
@@ -9,7 +10,9 @@ export const metadata: Metadata = {
     "Short stories celebrating the incredible builders who shaped Canada.",
 };
 
-export default function BuildersPage() {
+export default async function BuildersPage() {
+  const builders = await fetchBuilders();
+
   return (
     <div className="mx-[10px] my-[10px] border border-border-light bg-bg">
       <section className="px-5 py-12">
@@ -27,12 +30,15 @@ export default function BuildersPage() {
                 className="group border border-border-light overflow-hidden hover:border-dark transition-colors"
               >
                 <div className="relative w-full h-[200px] overflow-hidden bg-border-light">
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={builder.gif}
-                    alt={`${builder.name} — ${builder.tagline}`}
-                    className="w-full h-full object-cover"
-                  />
+                  {builder.imageUrl && (
+                    <Image
+                      src={builder.imageUrl}
+                      alt={`${builder.name} — ${builder.tagline}`}
+                      fill
+                      className="object-cover"
+                      unoptimized
+                    />
+                  )}
                 </div>
                 <div className="p-5">
                   <h2 className="font-display text-[1.25rem] font-normal leading-[1.2] text-dark mb-1 group-hover:underline">
@@ -41,9 +47,11 @@ export default function BuildersPage() {
                   <p className="type-label-sm text-text-secondary uppercase">
                     {builder.tagline}
                   </p>
-                  <p className="type-body-sm text-text-secondary mt-2 line-clamp-2">
-                    &ldquo;{builder.quote}&rdquo;
-                  </p>
+                  {builder.quote && (
+                    <p className="type-body-sm text-text-secondary mt-2 line-clamp-2">
+                      &ldquo;{builder.quote}&rdquo;
+                    </p>
+                  )}
                 </div>
               </Link>
             ))}

--- a/src/app/builders/page.tsx
+++ b/src/app/builders/page.tsx
@@ -1,0 +1,55 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import SectionLabel from "@/components/SectionLabel";
+import { builders } from "@/lib/builders";
+
+export const metadata: Metadata = {
+  title: "Great Canadian Builders",
+  description:
+    "Short stories celebrating the incredible builders who shaped Canada.",
+};
+
+export default function BuildersPage() {
+  return (
+    <div className="mx-[10px] my-[10px] border border-border-light bg-bg">
+      <section className="px-5 py-12">
+        <div className="max-w-[1080px] mx-auto">
+          <SectionLabel as="h2">Great Canadian Builders</SectionLabel>
+          <p className="type-body text-text-secondary mb-8">
+            Short stories celebrating the incredible builders who shaped Canada.
+          </p>
+
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-2.5">
+            {builders.map((builder) => (
+              <Link
+                key={builder.slug}
+                href={`/builders/${builder.slug}`}
+                className="group border border-border-light overflow-hidden hover:border-dark transition-colors"
+              >
+                <div className="relative w-full h-[200px] overflow-hidden bg-border-light">
+                  {/* eslint-disable-next-line @next/next/no-img-element */}
+                  <img
+                    src={builder.gif}
+                    alt={`${builder.name} — ${builder.tagline}`}
+                    className="w-full h-full object-cover"
+                  />
+                </div>
+                <div className="p-5">
+                  <h2 className="font-display text-[1.25rem] font-normal leading-[1.2] text-dark mb-1 group-hover:underline">
+                    {builder.name}
+                  </h2>
+                  <p className="type-label-sm text-text-secondary uppercase">
+                    {builder.tagline}
+                  </p>
+                  <p className="type-body-sm text-text-secondary mt-2 line-clamp-2">
+                    &ldquo;{builder.quote}&rdquo;
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/builders/page.tsx
+++ b/src/app/builders/page.tsx
@@ -35,7 +35,7 @@ export default async function BuildersPage() {
                       src={builder.imageUrl}
                       alt={`${builder.name} — ${builder.tagline}`}
                       fill
-                      className="object-cover"
+                      className="object-cover object-top"
                       unoptimized
                     />
                   )}

--- a/src/app/content/[id]/page.tsx
+++ b/src/app/content/[id]/page.tsx
@@ -111,8 +111,7 @@ export default async function ContentItemPage({
         <div className="flex items-center gap-3 mt-5 pb-5 border-b border-border-light">
           {item.authorPhoto ? (
             <div
-              className="w-9 h-9 overflow-hidden shrink-0"
-              style={{ borderRadius: 2 }}
+              className="w-9 h-9 overflow-hidden shrink-0 rounded-none"
             >
               <Image
                 src={item.authorPhoto}
@@ -125,8 +124,7 @@ export default async function ContentItemPage({
             </div>
           ) : (
             <div
-              className="w-9 h-9 bg-border-light flex items-center justify-center type-label-sm text-text-secondary shrink-0"
-              style={{ borderRadius: 2 }}
+              className="w-9 h-9 bg-border-light flex items-center justify-center type-label-sm text-text-secondary shrink-0 rounded-none"
             >
               {item.author.charAt(0).toUpperCase()}
             </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -14,7 +14,7 @@ export const metadata: Metadata = {
   description:
     "Canada's Voice for Builders. Bold thinking from builders, reformers, and leaders pushing Canada to new frontiers.",
   metadataBase: new URL(
-    process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.ca"
+    process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.com"
   ),
   openGraph: {
     type: "website",

--- a/src/app/memos/MemoResultsList.tsx
+++ b/src/app/memos/MemoResultsList.tsx
@@ -15,8 +15,7 @@ function MemoGridRow({ memo }: { memo: MemoItem }) {
     >
       <div className="flex items-start gap-4 p-5 flex-1">
         <div
-          className="w-10 h-10 bg-border-light shrink-0 overflow-hidden mt-0.5"
-          style={{ borderRadius: "2px" }}
+          className="w-10 h-10 bg-border-light shrink-0 overflow-hidden mt-0.5 rounded-none"
         >
           {memo.author.photo && (
             <Image

--- a/src/app/memos/[slug]/MemoClientParts.tsx
+++ b/src/app/memos/[slug]/MemoClientParts.tsx
@@ -87,7 +87,7 @@ export function RelatedMemos({ related }: { related: RelatedMemo[] }) {
             href={`/memos/${m.slug}`}
             className="flex items-start gap-3 group"
           >
-            <div className="w-8 h-8 rounded-full bg-charcoal-300 overflow-hidden shrink-0 mt-0.5">
+            <div className="w-8 h-8 rounded-none bg-charcoal-300 overflow-hidden shrink-0 mt-0.5">
               {m.author.photo && (
                 // eslint-disable-next-line @next/next/no-img-element
                 <img

--- a/src/app/memos/[slug]/page.tsx
+++ b/src/app/memos/[slug]/page.tsx
@@ -192,7 +192,7 @@ export default async function MemoDetailPage({
             </h1>
 
             <div className="flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-white/20 overflow-hidden shrink-0">
+              <div className="w-10 h-10 rounded-none bg-white/20 overflow-hidden shrink-0">
                 {authorImage && (
                   <Image
                     src={authorImage}
@@ -246,7 +246,7 @@ export default async function MemoDetailPage({
               <h1 className="type-title mb-4">{memo.title}</h1>
 
               <div className="flex items-center gap-3 mb-6">
-                <div className="w-10 h-10 rounded-full bg-border-light overflow-hidden shrink-0">
+                <div className="w-10 h-10 rounded-none bg-border-light overflow-hidden shrink-0">
                   {authorImage && (
                     <Image
                       src={authorImage}

--- a/src/app/privacy-notice/page.tsx
+++ b/src/app/privacy-notice/page.tsx
@@ -1,0 +1,105 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Notice",
+  description: "Build Canada privacy notice — how we collect, use, and protect your information.",
+};
+
+export default function PrivacyNoticePage() {
+  return (
+    <div className="mx-[10px] my-[10px] border border-border-light bg-bg">
+      <article className="animate-fade-in max-w-2xl mx-auto px-5 pt-[50px] pb-[60px]">
+        <h1 className="type-title mb-8">Privacy Notice</h1>
+
+        <section className="space-y-6">
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Who we are</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              Build Canada&apos;s Prosperity Inc. (&ldquo;Build Canada&rdquo;, &ldquo;we&rdquo;, &ldquo;us&rdquo;) is a non-profit, non-partisan community for builders. We respect your privacy.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">What we collect</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              Information you give us (e.g., name, email, postal code, city/chapter, RSVPs, survey responses, messages). Basic device/usage data from cookies/analytics. Payment info is handled by our providers; we don&apos;t store full card numbers.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Why we use it</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              To run our community and events, communicate with you, improve our programs, ensure safety, and meet legal requirements. We rely on your consent, which you can withdraw (we&apos;ll explain any impacts).
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Sharing</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              We use trusted service providers (email, ticketing, payments, analytics) under contracts that protect your information. We <strong>do not sell</strong> personal information.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Storage &amp; transfers</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              Your information may be stored or accessed outside your province or Canada by our providers. We remain responsible for it and apply safeguards appropriate to the sensitivity of the data.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Retention</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              We keep information only as long as needed for the purposes above or as required by law, then delete or de-identify it.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Your choices &amp; rights</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              Unsubscribe from emails anytime. You may request access to or correction of your information, or ask us to withdraw consent. Contact us at{" "}
+              <a href="mailto:hello@buildcanada.com" className="underline hover:text-dark transition-colors">
+                hello@buildcanada.com
+              </a>.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Security</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              We use administrative, technical, and physical safeguards. No method is 100% secure.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Children</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              Our services aren&apos;t directed to children under 13. If a child provided information, contact us to remove it.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Questions or complaints</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              Email us at{" "}
+              <a href="mailto:hello@buildcanada.com" className="underline hover:text-dark transition-colors">
+                hello@buildcanada.com
+              </a>. You may also contact the Office of the Privacy Commissioner of Canada or your provincial privacy regulator.
+            </p>
+          </div>
+
+          <div>
+            <h2 className="type-h3 text-dark mb-2">Updates</h2>
+            <p className="type-body text-text-secondary leading-relaxed">
+              We may update this Notice from time to time. The latest version will always apply.
+            </p>
+          </div>
+
+          <p className="type-label text-text-muted pt-4 border-t border-border-light">
+            Effective: September 6, 2025
+          </p>
+        </section>
+      </article>
+    </div>
+  );
+}

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,7 @@
 import type { MetadataRoute } from "next";
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.ca";
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.com";
 
   return {
     rules: [

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,15 +1,25 @@
 import type { MetadataRoute } from "next";
 import { fetchFeedItems, fetchMemos } from "@/lib/api";
+import { builders } from "@/lib/builders";
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.ca";
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.com";
 
   const staticPages: MetadataRoute.Sitemap = [
     { url: baseUrl, lastModified: new Date(), changeFrequency: "daily", priority: 1 },
     { url: `${baseUrl}/memos`, lastModified: new Date(), changeFrequency: "daily", priority: 0.9 },
     { url: `${baseUrl}/content`, lastModified: new Date(), changeFrequency: "daily", priority: 0.8 },
+    { url: `${baseUrl}/builders`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.7 },
     { url: `${baseUrl}/about`, lastModified: new Date(), changeFrequency: "monthly", priority: 0.5 },
+    { url: `${baseUrl}/privacy-notice`, lastModified: new Date(), changeFrequency: "yearly", priority: 0.3 },
   ];
+
+  const builderPages: MetadataRoute.Sitemap = builders.map((b) => ({
+    url: `${baseUrl}/builders/${b.slug}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly",
+    priority: 0.6,
+  }));
 
   const memos = await fetchMemos();
   const memoPages: MetadataRoute.Sitemap = memos.map((m) => ({
@@ -27,5 +37,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.6,
   }));
 
-  return [...staticPages, ...memoPages, ...feedPages];
+  return [...staticPages, ...builderPages, ...memoPages, ...feedPages];
 }

--- a/src/components/TestimonialsBlock.tsx
+++ b/src/components/TestimonialsBlock.tsx
@@ -45,10 +45,10 @@ function TestimonialCard({ testimonial }: { testimonial: Testimonial }) {
           <img
             src={testimonial.profilePhoto}
             alt={testimonial.name}
-            className="w-[40px] h-[40px] rounded-full object-cover"
+            className="w-[40px] h-[40px] rounded-none object-cover"
           />
         ) : (
-          <div className="w-[40px] h-[40px] rounded-full bg-charcoal-300" />
+          <div className="w-[40px] h-[40px] rounded-none bg-charcoal-300" />
         )}
         <div>
           <p className="type-heading text-[14px]">{testimonial.name}</p>

--- a/src/components/feed/SocialCardHeader.tsx
+++ b/src/components/feed/SocialCardHeader.tsx
@@ -24,7 +24,7 @@ export function SocialCardHeader({
     <div className="flex items-center gap-2.5 px-5 py-3 border-b" style={{ borderColor }}>
       <div
         className="w-8 h-8 overflow-hidden shrink-0"
-        style={{ borderRadius: 2, border: `2px solid ${avatarBorder}` }}
+        style={{ border: `2px solid ${avatarBorder}` }}
       >
         <Image
           src="/assets/logos/Logocircle.webp"

--- a/src/components/share/ui/OGPreview.tsx
+++ b/src/components/share/ui/OGPreview.tsx
@@ -6,11 +6,11 @@ interface OGPreviewProps {
 }
 
 export function OGPreview({ title, description, image, url }: OGPreviewProps) {
-  let domain = "buildcanada.ca";
+  let domain = "buildcanada.com";
   try {
     domain = new URL(url).hostname;
   } catch {
-    domain = "buildcanada.ca";
+    domain = "buildcanada.com";
   }
 
   return (

--- a/src/components/ui/memo-card.tsx
+++ b/src/components/ui/memo-card.tsx
@@ -121,7 +121,6 @@ export function MemoCard({
             "bg-border-light overflow-hidden shrink-0",
             isFeatured ? "w-14 h-14 lg:w-16 lg:h-16" : "w-12 h-12 lg:w-[60px] lg:h-[60px]"
           )}
-          style={{ borderRadius: '2px' }}
         >
           <Image
             src={memo.author.photo}
@@ -222,8 +221,7 @@ export function MemoCard({
               {memo.author.photo && (
                 <div 
                   className="w-10 h-10 lg:w-12 lg:h-12 bg-border-light overflow-hidden shrink-0"
-                  style={{ borderRadius: '2px' }}
-                >
+                        >
                   <Image
                     src={memo.author.photo}
                     alt={memo.author.name}

--- a/src/components/widgets/GreatBuildersWidget.tsx
+++ b/src/components/widgets/GreatBuildersWidget.tsx
@@ -1,34 +1,9 @@
 "use client";
 
 import { useState, useEffect } from "react";
+import Link from "next/link";
+import { builders } from "@/lib/builders";
 import { WidgetProps } from "./types";
-
-const builders = [
-  {
-    name: "Diana Matheson",
-    tagline: "Building the Future of Canadian Soccer",
-    quote: "If there\u2019s something you want to do and you feel like you\u2019re the right person for the job, go do it.",
-    gif: "/assets/images/diana-matheson-canadian-soccer.gif",
-  },
-  {
-    name: "Robert Bourassa",
-    tagline: "The Project of the Century",
-    quote: "Never let it be said that we shall live like paupers on a land this rich.",
-    gif: "/assets/images/robert-bourassa-quebec-premier.gif",
-  },
-  {
-    name: "Mary Pickford",
-    tagline: "She Invented the Movie Star",
-    quote: "You may have a fresh start any moment you choose, for this thing that we call \u2018failure\u2019 is not the falling down, but the staying down.",
-    gif: "/assets/images/mary-pickford-hollywood-pioneer.gif",
-  },
-  {
-    name: "Alexander Graham Bell",
-    tagline: "A Life Wired for Meaning",
-    quote: "The inventor looks upon the world and is not contented with things as they are. He wants to improve whatever he sees.",
-    gif: "/assets/images/alexander-graham-bell-inventor.gif",
-  },
-];
 
 export default function GreatBuildersWidget({ project }: WidgetProps) {
   const [index, setIndex] = useState(0);
@@ -84,14 +59,14 @@ export default function GreatBuildersWidget({ project }: WidgetProps) {
           ))}
         </div>
 
-        <div>
-          <p className="font-display text-[1.25rem] lg:text-[1.5rem] font-normal leading-[1.2] text-dark mb-1">
+        <Link href={`/builders/${builder.slug}`} className="group block">
+          <p className="font-display text-[1.25rem] lg:text-[1.5rem] font-normal leading-[1.2] text-dark mb-1 group-hover:underline">
             {builder.name}
           </p>
           <p className="type-label-sm text-text-secondary uppercase truncate">
             {builder.tagline}
           </p>
-        </div>
+        </Link>
       </div>
 
       <div className="hidden md:block w-px bg-border-light shrink-0" />

--- a/src/components/widgets/WidgetCard.tsx
+++ b/src/components/widgets/WidgetCard.tsx
@@ -13,8 +13,8 @@ export default function WidgetCard({ project }: { project: ProjectData }) {
     <div
       className={`flex flex-col h-full border border-border-light hover:border-dark transition-colors ${
         isBig
-          ? "min-h-[280px] md:min-h-[180px] md:col-span-2"
-          : "min-h-[200px]"
+          ? "min-h-[380px] md:min-h-[340px] md:col-span-2"
+          : "min-h-[360px]"
       }`}
     >
       <div className="flex-1">

--- a/src/components/widgets/WidgetPlaceholder.tsx
+++ b/src/components/widgets/WidgetPlaceholder.tsx
@@ -2,52 +2,29 @@ import Image from "next/image";
 import { ProjectData } from "./types";
 
 export default function WidgetPlaceholder({ project }: { project: ProjectData }) {
-  if (project.imageUrl) {
-    return (
-      <div className="relative h-full min-h-[180px]">
-        <Image
-          src={project.imageUrl}
-          alt={project.title}
-          fill
-          className="object-cover"
-          unoptimized
-        />
-        <div className="absolute bottom-0 left-0 p-8 lg:p-10">
-          <span className="type-label font-bold text-white mb-1 block drop-shadow-md">
-            {project.title}
-          </span>
-        </div>
-      </div>
-    );
-  }
-
-  const isBig = project.featured;
-
   return (
     <div className="p-8 lg:p-10 h-full flex flex-col">
-      <span className="type-label font-bold text-text-secondary mb-3">
+      <span className="type-label font-bold text-text-secondary">
         {project.title}
       </span>
-      {isBig ? (
-        <>
-          <div className="flex-1 flex items-end gap-1.5">
-            {["55%", "80%", "65%", "100%", "45%", "70%", "90%", "50%"].map((h, i) => (
-              <div
-                key={i}
-                className="flex-1 bg-border-light"
-                style={{ height: h }}
-              />
-            ))}
-          </div>
-          {project.description && (
-            <p className="type-body-sm text-text-secondary mt-3 line-clamp-1">
-              {project.description}
-            </p>
-          )}
-        </>
+      {project.description && (
+        <p className="type-body-sm text-text-secondary mt-2">
+          {project.description}
+        </p>
+      )}
+      {project.imageUrl ? (
+        <div className="relative flex-1 mt-4 min-h-[120px]">
+          <Image
+            src={project.imageUrl}
+            alt={project.title}
+            fill
+            className="object-cover object-top"
+            unoptimized
+          />
+        </div>
       ) : (
-        <div className="flex-1 flex items-end gap-1">
-          {["60%", "100%", "75%", "45%", "85%", "55%"].map((h, i) => (
+        <div className="flex-1 flex items-end gap-1.5 mt-4">
+          {["55%", "80%", "65%", "100%", "45%", "70%", "90%", "50%"].map((h, i) => (
             <div
               key={i}
               className="flex-1 bg-border-light"

--- a/src/components/widgets/WidgetPlaceholder.tsx
+++ b/src/components/widgets/WidgetPlaceholder.tsx
@@ -13,7 +13,7 @@ export default function WidgetPlaceholder({ project }: { project: ProjectData })
         </p>
       )}
       {project.imageUrl ? (
-        <div className="relative flex-1 mt-4 min-h-[120px]">
+        <div className="relative flex-1 mt-4 min-h-[200px]">
           <Image
             src={project.imageUrl}
             alt={project.title}

--- a/src/components/widgets/WidgetPlaceholder.tsx
+++ b/src/components/widgets/WidgetPlaceholder.tsx
@@ -12,16 +12,10 @@ export default function WidgetPlaceholder({ project }: { project: ProjectData })
           className="object-cover"
           unoptimized
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
         <div className="absolute bottom-0 left-0 p-8 lg:p-10">
-          <span className="type-label font-bold text-white mb-1 block">
+          <span className="type-label font-bold text-white mb-1 block drop-shadow-md">
             {project.title}
           </span>
-          {project.description && (
-            <p className="type-body-sm text-white/70 line-clamp-2">
-              {project.description}
-            </p>
-          )}
         </div>
       </div>
     );

--- a/src/components/widgets/WidgetPlaceholder.tsx
+++ b/src/components/widgets/WidgetPlaceholder.tsx
@@ -1,6 +1,32 @@
+import Image from "next/image";
 import { ProjectData } from "./types";
 
 export default function WidgetPlaceholder({ project }: { project: ProjectData }) {
+  if (project.imageUrl) {
+    return (
+      <div className="relative h-full min-h-[180px]">
+        <Image
+          src={project.imageUrl}
+          alt={project.title}
+          fill
+          className="object-cover"
+          unoptimized
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+        <div className="absolute bottom-0 left-0 p-8 lg:p-10">
+          <span className="type-label font-bold text-white mb-1 block">
+            {project.title}
+          </span>
+          {project.description && (
+            <p className="type-body-sm text-white/70 line-clamp-2">
+              {project.description}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   const isBig = project.featured;
 
   return (

--- a/src/components/widgets/types.ts
+++ b/src/components/widgets/types.ts
@@ -10,6 +10,7 @@ export interface ProjectData {
   featured: boolean;
   order: number;
   accentColor: string | null;
+  imageUrl: string | null;
 }
 
 export interface WidgetProps {

--- a/src/lib/api/builders.ts
+++ b/src/lib/api/builders.ts
@@ -1,0 +1,72 @@
+import { apiFetch } from "./client";
+import type { YFPaginatedResponse } from "./types";
+
+interface YFBuilder {
+  id: number;
+  slug: string;
+  title: string;
+  byline: string | null;
+  quote: string | null;
+  image_url: string | null;
+}
+
+interface YFBuilderDetail extends YFBuilder {
+  body: string | null;
+  author: string | null;
+}
+
+export interface BuilderSerialized {
+  id: string;
+  slug: string;
+  name: string;
+  tagline: string | null;
+  quote: string | null;
+  imageUrl: string | null;
+}
+
+export interface BuilderDetailSerialized extends BuilderSerialized {
+  body: string | null;
+  author: string | null;
+}
+
+function stripHtml(html: string | null): string | null {
+  if (!html) return null;
+  return html.replace(/<[^>]*>/g, "").trim();
+}
+
+function mapBuilder(b: YFBuilder): BuilderSerialized {
+  return {
+    id: String(b.id),
+    slug: b.slug,
+    name: b.title,
+    tagline: b.byline,
+    quote: stripHtml(b.quote),
+    imageUrl: b.image_url,
+  };
+}
+
+export async function fetchBuilders(): Promise<BuilderSerialized[]> {
+  const all: YFBuilder[] = [];
+  let page = 1;
+
+  while (true) {
+    const res = await apiFetch<YFPaginatedResponse<YFBuilder>>("/builders", {
+      params: { page: String(page) },
+      revalidate: 3600,
+    });
+    all.push(...res.data);
+    if (page >= res.pagination.pages) break;
+    page++;
+  }
+
+  return all.map(mapBuilder);
+}
+
+export async function fetchBuilder(slug: string): Promise<BuilderDetailSerialized> {
+  const b = await apiFetch<YFBuilderDetail>(`/builders/${slug}`, { revalidate: 300 });
+  return {
+    ...mapBuilder(b),
+    body: b.body,
+    author: stripHtml(b.author),
+  };
+}

--- a/src/lib/api/config.ts
+++ b/src/lib/api/config.ts
@@ -11,7 +11,7 @@ export function getSiteConfig(): SiteConfigData {
     orgName: "Build Canada",
     orgDescription:
       "Build Canada is a civic organization on a mission to make Canada the most prosperous country in the world.",
-    siteUrl: process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.ca",
+    siteUrl: process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.com",
     logoUrl: "/assets/logos/logo-standard.svg",
     socialLinks: JSON.stringify([
       { platform: "x", url: "https://x.com/build_canada" },

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -1,4 +1,5 @@
 export { apiFetch } from "./client";
+export { fetchBuilder, fetchBuilders } from "./builders";
 export { getSiteConfig } from "./config";
 export { fetchFaqs } from "./faqs";
 export { fetchFeedItem, fetchFeedItems, fetchFeedItemsSimple } from "./feed";

--- a/src/lib/api/memos.ts
+++ b/src/lib/api/memos.ts
@@ -34,7 +34,7 @@ function mapMemo(m: YFMemo & { key_messages?: unknown[]; splash_image_url?: stri
     slug: m.slug,
     author: {
       name: authorName,
-      photo: authorName === "Build Canada" ? "/assets/logos/Logocircle.webp" : null,
+      photo: authorName === "Build Canada" ? "/assets/logos/Logocircle.webp" : (m.author?.profile_photo_url ?? null),
     },
     keyMessage1: keyMessages[0] ?? null,
     keyMessage2: keyMessages[1] ?? null,
@@ -86,7 +86,7 @@ export async function fetchMemo(slug: string) {
     author: {
       name: authorName,
       slug: m.author?.slug ?? "",
-      photo: authorName === "Build Canada" ? "/assets/logos/Logocircle.webp" : null,
+      photo: authorName === "Build Canada" ? "/assets/logos/Logocircle.webp" : (m.author?.profile_photo_url ?? null),
       title: m.author_title,
       bio: null as string | null,
       websiteUrl: null as string | null,

--- a/src/lib/api/tools.ts
+++ b/src/lib/api/tools.ts
@@ -2,12 +2,17 @@ import { apiFetch } from "./client";
 import type { YFTool, YFListResponse } from "./types";
 import type { ProjectData } from "@/components/widgets/types";
 
+function stripHtml(html: string | null): string | null {
+  if (!html) return null;
+  return html.replace(/<[^>]*>/g, "").trim();
+}
+
 function mapTool(t: YFTool): ProjectData {
   return {
     id: String(t.id),
     slug: t.slug,
     title: t.title,
-    description: t.description,
+    description: stripHtml(t.description),
     externalUrl: t.url,
     size: t.size,
     featured: t.featured,

--- a/src/lib/api/tools.ts
+++ b/src/lib/api/tools.ts
@@ -13,6 +13,7 @@ function mapTool(t: YFTool): ProjectData {
     featured: t.featured,
     order: t.position,
     accentColor: t.accent_color,
+    imageUrl: t.image_url,
   };
 }
 

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -18,6 +18,7 @@ export interface YFAuthor {
   id: number;
   name: string;
   slug: string;
+  profile_photo_url?: string | null;
 }
 
 export interface YFMemo {

--- a/src/lib/builders.ts
+++ b/src/lib/builders.ts
@@ -1,0 +1,75 @@
+export interface Builder {
+  slug: string;
+  name: string;
+  tagline: string;
+  quote: string;
+  gif: string;
+  story: string;
+}
+
+export const builders: Builder[] = [
+  {
+    slug: "diana-matheson",
+    name: "Diana Matheson",
+    tagline: "Building the Future of Canadian Soccer",
+    quote:
+      "If there\u2019s something you want to do and you feel like you\u2019re the right person for the job, go do it.",
+    gif: "/assets/images/diana-matheson-canadian-soccer.gif",
+    story: `Diana Matheson is one of Canada\u2019s most decorated soccer players \u2014 and now, one of its most ambitious sports entrepreneurs. After a career that included two Olympic bronze medals and over 200 international appearances, she turned her attention to building something new: a professional women\u2019s soccer league in Canada.
+
+As co-founder of Project 8 Sports, Matheson launched the Northern Super League, Canada\u2019s first professional women\u2019s soccer league. The league debuted in April 2025 with eight founding clubs across the country.
+
+For Matheson, building isn\u2019t just about creating a league \u2014 it\u2019s about building infrastructure for the next generation. She saw a gap in Canadian sport: world-class female athletes with no professional league to play in at home. Rather than wait for someone else to fix it, she went and built the solution herself.
+
+Her story is a reminder that builders don\u2019t just work in tech or policy. They work wherever they see something broken and decide to fix it.`,
+  },
+  {
+    slug: "robert-bourassa",
+    name: "Robert Bourassa",
+    tagline: "The Project of the Century",
+    quote:
+      "Never let it be said that we shall live like paupers on a land this rich.",
+    gif: "/assets/images/robert-bourassa-quebec-premier.gif",
+    story: `Robert Bourassa served as Premier of Quebec for a combined fifteen years across two stints in office. But his most enduring legacy is one of the most ambitious infrastructure projects in human history: the James Bay hydroelectric project.
+
+Announced in 1971, the project sought to harness the rivers of northern Quebec to generate massive amounts of hydroelectric power. The scale was staggering \u2014 thousands of workers, billions of dollars, and some of the largest dams and reservoirs ever constructed. Critics called it impossible. Bourassa called it the project of the century.
+
+He was right. The James Bay project transformed Quebec into a clean energy powerhouse, providing the province with some of the cheapest electricity in North America. It remains one of the largest hydroelectric systems in the world.
+
+Bourassa\u2019s vision was rooted in a belief that Canada\u2019s natural resources should be a source of prosperity, not something to leave untouched. His willingness to think at a scale that others considered reckless is what made the project possible.`,
+  },
+  {
+    slug: "mary-pickford",
+    name: "Mary Pickford",
+    tagline: "She Invented the Movie Star",
+    quote:
+      "You may have a fresh start any moment you choose, for this thing that we call \u2018failure\u2019 is not the falling down, but the staying down.",
+    gif: "/assets/images/mary-pickford-hollywood-pioneer.gif",
+    story: `Born Gladys Louise Smith in Toronto in 1892, Mary Pickford became the most famous woman in the world. She didn\u2019t just act in movies \u2014 she invented what it meant to be a movie star.
+
+Pickford was the first actress to be billed by name, the first to earn a million-dollar contract, and the first to have true creative control over her films. She co-founded United Artists in 1919 alongside Charlie Chaplin, Douglas Fairbanks, and D.W. Griffith, giving artists ownership over their work in an industry that treated them as disposable.
+
+She also co-founded the Academy of Motion Picture Arts and Sciences and won one of the first Academy Awards. In an era when women had few paths to power, Pickford built her own.
+
+Pickford\u2019s legacy isn\u2019t just about entertainment. She proved that Canadians could compete on the world stage \u2014 and win. She left Toronto with almost nothing and built an empire through talent, shrewdness, and relentless ambition.`,
+  },
+  {
+    slug: "alexander-graham-bell",
+    name: "Alexander Graham Bell",
+    tagline: "A Life Wired for Meaning",
+    quote:
+      "The inventor looks upon the world and is not contented with things as they are. He wants to improve whatever he sees.",
+    gif: "/assets/images/alexander-graham-bell-inventor.gif",
+    story: `Alexander Graham Bell is best known for inventing the telephone, but his story is really about a life devoted to solving problems that others overlooked.
+
+Born in Edinburgh, Bell immigrated to Canada in 1870 and settled in Brantford, Ontario, where he conducted many of his early experiments. His interest in sound and communication was deeply personal \u2014 both his mother and his wife were deaf, and much of his early work focused on improving communication for the hearing impaired.
+
+The telephone, patented in 1876, changed the world. But Bell didn\u2019t stop there. He went on to work on the photophone, the metal detector, and early concepts for the airplane. He co-founded the National Geographic Society and continued inventing until his death in 1922 at his estate in Nova Scotia.
+
+Bell\u2019s Canadian years were formative. The quiet of Brantford gave him the space to think, and Canada\u2019s emerging scientific community gave him collaborators and supporters. He embodies the builder\u2019s mindset: see a problem, understand it deeply, and build something to solve it.`,
+  },
+];
+
+export function getBuilderBySlug(slug: string): Builder | undefined {
+  return builders.find((b) => b.slug === slug);
+}

--- a/src/lib/og-image-template.tsx
+++ b/src/lib/og-image-template.tsx
@@ -109,7 +109,7 @@ export function BuildCanadaOGImage({ title, description, badge, label }: OGImage
           </span>
         )}
         <span style={{ fontSize: "28px", color: theme.foreground30, marginLeft: "auto" }}>
-          buildcanada.ca
+          buildcanada.com
         </span>
       </div>
     </div>

--- a/src/lib/schemas/entities/author.ts
+++ b/src/lib/schemas/entities/author.ts
@@ -16,7 +16,7 @@ export function createAuthor(data: AuthorData): Person {
         "@type": "ImageObject",
         url: data.image.startsWith("http")
           ? data.image
-          : `https://buildcanada.ca${data.image}`,
+          : `https://buildcanada.com${data.image}`,
       },
     }),
   };

--- a/src/lib/schemas/entities/organization.ts
+++ b/src/lib/schemas/entities/organization.ts
@@ -1,6 +1,6 @@
 import { Organization, WebSite } from "schema-dts";
 
-const SITE_URL = "https://buildcanada.ca";
+const SITE_URL = "https://buildcanada.com";
 
 export function createOrganization(): Organization {
   return {


### PR DESCRIPTION
## Summary
- Use author profile photos from the API on memo cards instead of hardcoded null
- Remove all border-radius from image containers across the site (sharp corners only)
- Replace inline `borderRadius` styles with Tailwind `rounded-none`

## Test plan
- [ ] Verify memo cards on homepage show author photos
- [ ] Verify memo detail pages show author photos with sharp corners
- [ ] Verify testimonial photos have no rounded corners
- [ ] Verify content feed author photos have no rounded corners

🤖 Generated with [Claude Code](https://claude.com/claude-code)