### PR TITLE
Fix build: add missing imageUrl property to BUILDERS_PROJECT

### DIFF
--- a/src/components/content/GreatBuildersSection.tsx
+++ b/src/components/content/GreatBuildersSection.tsx
@@ -12,6 +12,7 @@ const BUILDERS_PROJECT = {
   featured: false,
   order: 0,
   accentColor: null,
+  imageUrl: null,
 };
 
 export function GreatBuildersSection() {


### PR DESCRIPTION
The ProjectData interface requires imageUrl but the BUILDERS_PROJECT
constant in GreatBuildersSection was missing it, causing a TypeScript
compilation error during build.

https://claude.ai/code/session_01SV4U9idCSmAdwpbTjGumdF