### PR TITLE
feat: cycling hero text, feed picks API, memo/builder content types

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,6 +16,7 @@ const nextConfig: NextConfig = {
     ];
   },
   images: {
+    unoptimized: process.env.NODE_ENV === "development",
     remotePatterns: [
       {
         protocol: "https",
@@ -36,6 +37,14 @@ const nextConfig: NextConfig = {
       {
         protocol: "https",
         hostname: "york-factory.eng.canadasbuilding.com",
+      },
+      {
+        protocol: "https",
+        hostname: "yorkfactory.buildcanada.com",
+      },
+      {
+        protocol: "http",
+        hostname: "localhost",
       },
     ],
   },

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import FeaturedProjects from "@/components/FeaturedProjects";
 import { LinkButton } from "@/components/ui/link-button";
 import { SubscribeButton } from "@/components/ui/subscribe-button";
 import EventsTimeline from "@/components/EventsTimeline";
+import CyclingWord from "@/components/CyclingWord";
 import { buildGraph } from "@/lib/schemas/graph";
 import { generateOrganizationSchema } from "@/lib/schemas/generators/organization";
 import { generateWebSiteSchema } from "@/lib/schemas/generators/website";
@@ -85,7 +86,7 @@ function HeroSection() {
 
       <h1 className="relative z-10 type-display text-center">
         <span className="relative block">
-          <span className="text-white">Canada&apos;s Voice</span>
+          <span className="text-white">Building a </span>
           <span
             className="absolute left-1/2 -translate-x-1/2 bottom-[calc(0.2em-5px)] w-[200vw] h-px"
             style={{
@@ -96,14 +97,14 @@ function HeroSection() {
             }}
           />
         </span>
-        <span className="relative block">
-          <span
-            className="text-transparent"
-            style={{ WebkitTextStroke: "1px white" }}
-          >
-            for
-          </span>{" "}
-          <span className="text-white">Builders.</span>
+        <span className="relative block whitespace-nowrap">
+          <span className="invisible" aria-hidden="true">Stronger Canada.</span>
+          <span className="absolute right-1/2 top-0 mr-[0.15em] text-right text-transparent">
+            <CyclingWord />{" "}
+          </span>
+          <span className="absolute left-1/2 top-0 ml-[0.15em] text-white">
+            {" "}Canada.
+          </span>
           <span
             className="absolute left-1/2 -translate-x-1/2 bottom-[calc(0.2em-5px)] w-[200vw] h-px"
             style={{

--- a/src/components/CyclingWord.tsx
+++ b/src/components/CyclingWord.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+const words = [
+  "Better",
+  "Safer",
+  "Freer",
+  "Richer",
+  "Bolder",
+  "Stronger",
+  "Faster",
+  "Prouder",
+];
+
+type Phase = "in" | "visible" | "out";
+
+export default function CyclingWord() {
+  const [index, setIndex] = useState(0);
+  const [phase, setPhase] = useState<Phase>("in");
+  const ref = useRef<HTMLSpanElement>(null);
+
+  useEffect(() => {
+    const enterTimeout = setTimeout(() => setPhase("visible"), 50);
+    return () => clearTimeout(enterTimeout);
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      // Slide out downward
+      setPhase("out");
+      setTimeout(() => {
+        // Move to top position instantly (no transition)
+        setIndex((prev) => (prev + 1) % words.length);
+        if (ref.current) {
+          ref.current.style.transition = "none";
+          ref.current.style.transform = "translateY(-110%)";
+          ref.current.style.opacity = "0";
+          // Force reflow so the browser registers the position
+          ref.current.offsetHeight;
+          // Re-enable transition and slide in
+          ref.current.style.transition = "";
+          ref.current.style.transform = "";
+          ref.current.style.opacity = "";
+        }
+        setPhase("visible");
+      }, 200);
+    }, 3000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const transform =
+    phase === "in"
+      ? "translateY(-110%)"
+      : phase === "out"
+        ? "translateY(110%)"
+        : "translateY(0)";
+
+  const opacity = phase === "visible" ? 1 : 0;
+
+  return (
+    <span
+      className="inline-block overflow-hidden align-bottom pb-[0.1em]"
+      style={{ WebkitTextStroke: "1px white" }}
+    >
+      <span
+        ref={ref}
+        className="inline-block transition-all duration-200 ease-out"
+        style={{ transform, opacity }}
+      >
+        {words[index]}
+      </span>
+    </span>
+  );
+}

--- a/src/components/FeaturedProjects.tsx
+++ b/src/components/FeaturedProjects.tsx
@@ -7,7 +7,7 @@ export default function FeaturedProjects() {
     <section className="px-5 pt-[26px] pb-[36px] border-b border-border-light">
       <div className="max-w-[1080px] mx-auto">
         <SectionLabel>Projects</SectionLabel>
-        <ProjectsGrid featured maxItems={4} excludeSlugs={["great-builders"]} />
+        <ProjectsGrid includeSlugs={["outcomes-tracker", "canada-spends"]} columns={1} />
         <div className="flex justify-start mt-4">
           <LinkButton href="/projects" variant="primary">
             View All Projects

--- a/src/components/FeedPreview.tsx
+++ b/src/components/FeedPreview.tsx
@@ -1,20 +1,8 @@
-import { fetchFeedItemsSimple } from "@/lib/api";
-import { type FeedItem } from "@/components/feed/types";
+import { fetchFeedPicks } from "@/lib/api";
 import { IGCard, XCard, TikTokCard, SubstackCard, FeedCard } from "@/components/feed";
 
-async function getFeedPicks(): Promise<FeedItem[]> {
-  const all = await fetchFeedItemsSimple();
-  const picks: FeedItem[] = [];
-  const types = ["X", "IG", "SUBSTACK", "BLOG"];
-  for (const t of types) {
-    const match = all.find((d) => d.type === t);
-    if (match) picks.push(match);
-  }
-  return picks;
-}
-
 export default async function FeedPreview() {
-  const items = await getFeedPicks();
+  const items = await fetchFeedPicks("x,substack,memo|blog|builder,x:canada_spends");
 
   return (
     <div className="py-12">

--- a/src/components/PlatformIcon.tsx
+++ b/src/components/PlatformIcon.tsx
@@ -17,6 +17,8 @@ const LABELS: Record<string, string> = {
   YOUTUBE: "YouTube",
   LINKEDIN: "LinkedIn",
   BLOG: "Blog",
+  MEMO: "Memo",
+  BUILDER: "Builder",
 };
 
 export function PlatformIcon({

--- a/src/components/ProjectsGrid.tsx
+++ b/src/components/ProjectsGrid.tsx
@@ -7,15 +7,26 @@ export default async function ProjectsGrid({
   maxItems,
   filter,
   excludeSlugs,
+  includeSlugs,
+  columns,
 }: {
   featured?: boolean;
   maxItems?: number;
   filter?: "featured" | "non-featured";
   excludeSlugs?: string[];
+  includeSlugs?: string[];
+  columns?: 1 | 2;
 }) {
   const raw = await fetchTools(featured ? { featured: true } : undefined);
 
   let projects: ProjectData[] = raw;
+
+  if (includeSlugs?.length) {
+    const included = new Set(includeSlugs);
+    projects = includeSlugs
+      .map((slug) => projects.find((p) => p.slug === slug))
+      .filter((p): p is ProjectData => p != null);
+  }
 
   if (filter === "featured") {
     projects = projects.filter((p) => p.featured);
@@ -35,7 +46,7 @@ export default async function ProjectsGrid({
   if (projects.length === 0) return null;
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 gap-0">
+    <div className={`grid gap-0 ${columns === 1 ? "grid-cols-1" : "grid-cols-1 md:grid-cols-2"}`}>
       {projects.map((project) => (
         <WidgetCard key={project.id} project={project} />
       ))}

--- a/src/components/content/FeaturedPost.tsx
+++ b/src/components/content/FeaturedPost.tsx
@@ -39,7 +39,7 @@ export function FeaturedPost({ item }: { item: ContentFeedItem }) {
     <Link
       href={href}
       target={contentItemTarget(item)}
-      rel={item.type !== "BLOG" ? "noopener noreferrer" : undefined}
+      rel={contentItemTarget(item) ? "noopener noreferrer" : undefined}
       className="block"
     >
       {inner}

--- a/src/components/content/PlatformBadge.tsx
+++ b/src/components/content/PlatformBadge.tsx
@@ -1,16 +1,15 @@
 import Image from "next/image";
 
 export function PlatformBadge({ type }: { type: string }) {
-  const label =
-    type === "SUBSTACK"
-      ? "Substack"
-      : type === "BLOG"
-        ? "Blog"
-        : type === "TIKTOK"
-          ? "TikTok"
-          : type === "IG"
-            ? "IG"
-            : type;
+  const LABELS: Record<string, string> = {
+    SUBSTACK: "Substack",
+    BLOG: "Blog",
+    TIKTOK: "TikTok",
+    IG: "IG",
+    MEMO: "Memo",
+    BUILDER: "Builder",
+  };
+  const label = LABELS[type] || type;
   const hasSocialIcon = ["X", "TIKTOK", "IG", "SUBSTACK", "YOUTUBE"].includes(
     type
   );

--- a/src/components/content/PostListRow.tsx
+++ b/src/components/content/PostListRow.tsx
@@ -16,6 +16,8 @@ const PLATFORM_HOVER_CLASSES: Record<string, string> = {
   SUBSTACK: "group-hover/row:border-[#FF6719] group-hover/row:bg-[#FF6719]",
   YOUTUBE: "group-hover/row:border-[#FF0000] group-hover/row:bg-[#FF0000]",
   BLOG: "group-hover/row:border-[#932f2f] group-hover/row:bg-[#932f2f]",
+  MEMO: "group-hover/row:border-[#1a1a2e] group-hover/row:bg-[#1a1a2e]",
+  BUILDER: "group-hover/row:border-[#2d6a4f] group-hover/row:bg-[#2d6a4f]",
 };
 
 export function PostListRow({ item }: { item: ContentFeedItem }) {
@@ -85,7 +87,7 @@ export function PostListRow({ item }: { item: ContentFeedItem }) {
     <Link
       href={href}
       target={contentItemTarget(item)}
-      rel={item.type !== "BLOG" ? "noopener noreferrer" : undefined}
+      rel={contentItemTarget(item) ? "noopener noreferrer" : undefined}
       className="block"
     >
       {inner}

--- a/src/components/content/RecentCard.tsx
+++ b/src/components/content/RecentCard.tsx
@@ -34,7 +34,7 @@ export function RecentCard({ item }: { item: ContentFeedItem }) {
     <Link
       href={href}
       target={contentItemTarget(item)}
-      rel={item.type !== "BLOG" ? "noopener noreferrer" : undefined}
+      rel={contentItemTarget(item) ? "noopener noreferrer" : undefined}
       className="block"
     >
       {inner}

--- a/src/components/content/types.ts
+++ b/src/components/content/types.ts
@@ -7,15 +7,19 @@ export interface ContentFeedItem extends FeedItem {
 
 export { feedImage, itemHref };
 
+const INTERNAL_CONTENT_TYPES = new Set(["BLOG", "MEMO", "BUILDER"]);
+
 export function contentItemTarget(item: ContentFeedItem): string | undefined {
-  return item.type === "BLOG" ? undefined : "_blank";
+  return INTERNAL_CONTENT_TYPES.has(item.type) ? undefined : "_blank";
 }
 
-export const FILTERS = ["All", "Blog", "X", "TikTok", "IG", "Substack"] as const;
+export const FILTERS = ["All", "Memo", "Blog", "Builder", "X", "TikTok", "IG", "Substack"] as const;
 
 export const TYPE_MAP: Record<string, string> = {
   All: "All",
+  Memo: "MEMO",
   Blog: "BLOG",
+  Builder: "BUILDER",
   X: "X",
   TikTok: "TIKTOK",
   IG: "IG",
@@ -29,6 +33,8 @@ export const PLATFORM_HOVER_COLORS: Record<string, string> = {
   SUBSTACK: "#FF6719",
   YOUTUBE: "#FF0000",
   BLOG: "#932f2f",
+  MEMO: "#1a1a2e",
+  BUILDER: "#2d6a4f",
 };
 
 export const INVERT_ICON_ON_HOVER = new Set(["X", "IG"]);

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -13,10 +13,14 @@ const PLATFORM_ICONS: Record<string, string> = {
 
 const PLATFORM_LABELS: Record<string, string> = {
   BLOG: "Blog",
+  MEMO: "Memo",
+  BUILDER: "Builder",
   SUBSTACK: "Substack",
   TIKTOK: "TikTok",
   IG: "IG",
 };
+
+const INTERNAL_TYPES = new Set(["BLOG", "MEMO", "BUILDER"]);
 
 export function FeedCard({ item }: { item: FeedItem }) {
   const iconSlug = PLATFORM_ICONS[item.type];
@@ -25,8 +29,8 @@ export function FeedCard({ item }: { item: FeedItem }) {
   return (
     <Link
       href={itemHref(item)}
-      target={item.type !== "BLOG" ? "_blank" : undefined}
-      rel={item.type !== "BLOG" ? "noopener noreferrer" : undefined}
+      target={INTERNAL_TYPES.has(item.type) ? undefined : "_blank"}
+      rel={INTERNAL_TYPES.has(item.type) ? undefined : "noopener noreferrer"}
       className="border-b border-r border-border-light flex flex-col group overflow-hidden"
     >
       <div className="relative h-[100px] bg-dark">

--- a/src/components/feed/IGCard.tsx
+++ b/src/components/feed/IGCard.tsx
@@ -52,7 +52,7 @@ export function IGCard({ item }: { item: FeedItem }) {
         </span>
 
         {item.body && (
-          <p className="type-default line-clamp-4" style={{ color: COLORS.text }}>
+          <p className="type-default line-clamp-4 whitespace-pre-line" style={{ color: COLORS.text }}>
             <span className="font-display font-medium" style={{ letterSpacing: "-0.02em" }}>
               @build_canada
             </span>{" "}

--- a/src/components/feed/SocialCardHeader.tsx
+++ b/src/components/feed/SocialCardHeader.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { type FeedItem, formatFeedDate } from "./types";
+import { type FeedItem, formatFeedDate, isValidImage } from "./types";
 
 interface SocialCardHeaderProps {
   item: FeedItem;
@@ -20,6 +20,9 @@ export function SocialCardHeader({
   mutedColor,
   avatarBorder,
 }: SocialCardHeaderProps) {
+  const handle = item.accountHandle || "@build_canada";
+  const avatarSrc = isValidImage(item.authorPhoto) ? item.authorPhoto! : "/assets/logos/Logocircle.webp";
+
   return (
     <div className="flex items-center gap-2.5 px-5 py-3 border-b" style={{ borderColor }}>
       <div
@@ -27,8 +30,8 @@ export function SocialCardHeader({
         style={{ border: `2px solid ${avatarBorder}` }}
       >
         <Image
-          src="/assets/logos/Logocircle.webp"
-          alt="Build Canada"
+          src={avatarSrc}
+          alt={handle}
           width={32}
           height={32}
           className="object-cover"
@@ -39,7 +42,7 @@ export function SocialCardHeader({
           className="font-display text-[14px] font-medium leading-tight"
           style={{ color: textColor, letterSpacing: "-0.02em" }}
         >
-          @build_canada
+          {handle}
         </span>
         <span className="type-mono-sm leading-tight" style={{ color: mutedColor }}>
           {formatFeedDate(item.createdAt)}

--- a/src/components/feed/TikTokCard.tsx
+++ b/src/components/feed/TikTokCard.tsx
@@ -40,7 +40,7 @@ export function TikTokCard({ item }: { item: FeedItem }) {
         </span>
 
         {item.body && (
-          <p className="type-default text-[#e1e1e2] line-clamp-4">
+          <p className="type-default text-[#e1e1e2] line-clamp-4 whitespace-pre-line">
             {item.body}
           </p>
         )}

--- a/src/components/feed/XCard.tsx
+++ b/src/components/feed/XCard.tsx
@@ -41,7 +41,7 @@ export function XCard({ item }: { item: FeedItem }) {
         </span>
 
         {item.body && (
-          <p className="type-default text-[#e7e9ea] line-clamp-4">
+          <p className="type-default text-[#e7e9ea] line-clamp-4 whitespace-pre-line">
             {item.body}
           </p>
         )}

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -1,16 +1,22 @@
 export interface FeedItem {
   id: string;
   type: string;
+  feedableType: string | null;
   title: string | null;
   subtitle: string | null;
   author: string | null;
+  accountHandle: string | null;
   image: string | null;
   body: string | null;
   url: string | null;
+  slug: string | null;
+  authorPhoto: string | null;
+  publishedAt: string;
   createdAt: string;
 }
 
 export const SOCIAL_TYPES = new Set(["X", "TIKTOK", "IG", "YOUTUBE"]);
+export const INTERNAL_TYPES = new Set(["MEMO", "BLOG", "BUILDER"]);
 export const SOCIAL_FALLBACK_IMAGE = "/assets/logos/logo-standard.svg";
 
 export function isValidImage(src: string | null): boolean {
@@ -26,6 +32,8 @@ export function feedImage(item: FeedItem): string | null {
 
 export function itemHref(item: FeedItem): string {
   if (item.type === "BLOG") return `/content/${item.id}`;
+  if (item.type === "MEMO" && item.slug) return `/memos/${item.slug}`;
+  if (item.type === "BUILDER" && item.slug) return `/builders/${item.slug}`;
   return item.url || "/content";
 }
 

--- a/src/lib/api/feed.ts
+++ b/src/lib/api/feed.ts
@@ -7,14 +7,18 @@ function mapFeedItem(f: YFFeedItem): ContentFeedItem {
   return {
     id: String(f.id),
     type: f.item_type.toUpperCase(),
+    feedableType: f.feedable_type,
     title: f.title,
     subtitle: f.subtitle,
     author: f.author,
+    accountHandle: f.account_handle ?? null,
     image: f.image_url,
-    body: null,
+    body: f.body ?? null,
     url: f.url,
-    createdAt: new Date().toISOString(),
-    authorPhoto: null,
+    slug: f.slug,
+    publishedAt: f.published_at,
+    createdAt: f.published_at,
+    authorPhoto: f.author_photo_url ?? null,
     featured: f.featured,
   };
 }
@@ -23,13 +27,18 @@ function mapFeedItemToSimple(f: YFFeedItem): FeedItem {
   return {
     id: String(f.id),
     type: f.item_type.toUpperCase(),
+    feedableType: f.feedable_type,
     title: f.title,
     subtitle: f.subtitle,
     author: f.author,
+    accountHandle: f.account_handle ?? null,
     image: f.image_url,
-    body: null,
+    body: f.body ?? null,
     url: f.url,
-    createdAt: new Date().toISOString(),
+    slug: f.slug,
+    authorPhoto: f.author_photo_url ?? null,
+    publishedAt: f.published_at,
+    createdAt: f.published_at,
   };
 }
 
@@ -60,18 +69,31 @@ export async function fetchFeedItemsSimple(): Promise<FeedItem[]> {
   return res.data.map(mapFeedItemToSimple);
 }
 
+export async function fetchFeedPicks(
+  types: string = "x,ig,substack,memo"
+): Promise<FeedItem[]> {
+  const res = await apiFetch<{ data: YFFeedItem[] }>("/feed/picks", {
+    params: { types },
+    revalidate: 120,
+  });
+  return res.data.map(mapFeedItemToSimple);
+}
+
 export async function fetchFeedItem(id: string): Promise<ContentFeedItem> {
   const f = await apiFetch<YFFeedItemDetail>(`/feed/${id}`, { revalidate: 300 });
   return {
     id: String(f.id),
     type: f.item_type.toUpperCase(),
+    feedableType: f.feedable_type,
     title: f.title,
     subtitle: f.subtitle,
     author: f.author,
     image: f.image_url,
     body: f.body,
     url: f.url,
-    createdAt: new Date().toISOString(),
+    slug: f.slug,
+    publishedAt: f.published_at,
+    createdAt: f.published_at,
     authorPhoto: f.author_photo_url,
     featured: f.featured,
   };

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -2,7 +2,7 @@ export { apiFetch } from "./client";
 export { fetchBuilder, fetchBuilders } from "./builders";
 export { getSiteConfig } from "./config";
 export { fetchFaqs } from "./faqs";
-export { fetchFeedItem, fetchFeedItems, fetchFeedItemsSimple } from "./feed";
+export { fetchFeedItem, fetchFeedItems, fetchFeedItemsSimple, fetchFeedPicks } from "./feed";
 export { fetchMemo, fetchMemos } from "./memos";
 export { fetchTeamMembers } from "./team";
 export { fetchTestimonials } from "./testimonials";

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -90,19 +90,24 @@ export interface YFFaq {
 
 export interface YFFeedItem {
   id: number;
+  feedable_type: string;
   item_type: string;
   title: string | null;
   subtitle: string | null;
+  body: string | null;
   author: string | null;
+  account_handle: string | null;
   url: string | null;
+  slug: string | null;
   featured: boolean;
   tags: string[];
   image_url: string | null;
+  author_photo_url: string | null;
+  published_at: string;
 }
 
 export interface YFFeedItemDetail extends YFFeedItem {
   body: string | null;
   embed_code: string | null;
-  source_url: string | null;
   author_photo_url: string | null;
 }


### PR DESCRIPTION
## Summary

- **Cycling hero animation**: Hero heading now reads "Building a [word] Canada." where the word cycles through Better, Safer, Freer, Richer, Bolder, Stronger, Faster, Prouder with a slide-in/out transition every 3 seconds. "Canada." stays fixed at center.
- **Feed picks API**: Homepage feed preview now uses a new `/feed/picks` endpoint instead of client-side filtering
- **Memo & Builder content types**: Added MEMO and BUILDER as first-class content types across feed cards, platform badges, filters, and routing
- **Social card improvements**: Use API-provided author photos and account handles instead of hardcoded values
- **ProjectsGrid**: Added `includeSlugs` and `columns` props for more flexible project display
- **Image config**: Added yorkfactory.buildcanada.com and localhost to allowed remote image patterns

## Test plan

- [ ] Verify hero cycling animation works smoothly — words slide out bottom, new word slides in from top
- [ ] Verify "Canada." does not shift position when words cycle
- [ ] Verify text selection reads correctly (e.g. "Better Canada.")
- [ ] Check homepage feed preview loads picks correctly
- [ ] Verify memo and builder links route to correct pages
- [ ] Check social cards show correct author photos and handles

🤖 Generated with [Claude Code](https://claude.com/claude-code)