### PR TITLE
About: IFP-style FAQs + matching team/spacing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "packageManager": "pnpm@9.5.0",
   "scripts": {
     "dev": "next dev -p 5050",
-    "dev:remote": "YORK_FACTORY_API_URL=https://york-factory.eng.canadasbuilding.com/api/v1 next dev -p 5050",
+    "dev:remote": "YORK_FACTORY_API_URL=https://yorkfactory.buildcanada.com/api/v1 next dev -p 5050",
     "build": "next build",
     "start": "next start -p 5050",
     "lint": "eslint && npm run lint:tokens",

--- a/src/app/about/QnaBlock.tsx
+++ b/src/app/about/QnaBlock.tsx
@@ -7,7 +7,6 @@ import {
   AccordionItem,
   AccordionTrigger,
   AccordionContent,
-  AccordionChevron,
 } from "@/components/ui/accordion";
 
 interface QnaItem {
@@ -20,48 +19,55 @@ export default function QnaBlock({ items }: { items: QnaItem[] }) {
   const [openValue, setOpenValue] = useState<string[]>([]);
 
   return (
-    <section id="q-and-a" className="px-6 sm:px-16 py-16">
+    <section id="faqs" className="px-6 sm:px-16 py-16">
       <div className="max-w-screen-2xl mx-auto">
-        <SectionHeader label="Questions & Answers" />
-        <div className="mt-4 border border-border-light">
-          <Accordion value={openValue} onValueChange={setOpenValue}>
-            {items.map((item, i) => {
-              const value = `qna-${i}`;
-              const isOpen = openValue.includes(value);
+        <SectionHeader label="FAQs" />
+        <Accordion
+          value={openValue}
+          onValueChange={setOpenValue}
+          className="mt-4 grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-start"
+        >
+          {items.map((item, i) => {
+            const value = `qna-${i}`;
+            const isOpen = openValue.includes(value);
 
-              return (
-                <AccordionItem
-                  key={item.id}
-                  value={value}
-                  className="border-b-0 p-6"
+            return (
+              <AccordionItem
+                key={item.id}
+                value={value}
+                className="border-b border-border-light first:border-t md:[&:nth-child(-n+2)]:border-t"
+              >
+                <AccordionTrigger
+                   className="[&_[data-slot=accordion-trigger-icon]]:hidden flex items-center justify-between cursor-pointer group w-full text-left py-4 transition-colors rounded-none border-transparent hover:no-underline [&]:bg-transparent"
                 >
-                  <AccordionTrigger
-                     className="[&_[data-slot=accordion-trigger-icon]]:hidden flex items-center justify-between cursor-pointer group w-full text-left h-[48px] px-3 transition-colors rounded-none border-transparent hover:no-underline py-0 [&]:bg-transparent"
+                  <h3
+                    className={`type-h4 transition-colors duration-200 ${
+                      isOpen ? "text-accent" : "text-dark group-hover:text-accent"
+                    }`}
                   >
-                    <h3
-                      className={`type-h2 transition-colors duration-200 ${
-                        isOpen ? "text-accent" : "text-dark group-hover:text-accent"
-                      }`}
-                    >
-                      {item.question}
-                    </h3>
-                    <AccordionChevron isOpen={isOpen} />
-                  </AccordionTrigger>
-                  <AccordionContent
-                    panelClassName="accordion-expand"
-                    className="overflow-hidden"
+                    {item.question}
+                  </h3>
+                  <span
+                    className={`shrink-0 ml-4 transition-transform duration-200 ${
+                      isOpen ? "text-accent rotate-180" : "text-accent"
+                    }`}
                   >
-                    <div className="mt-4 px-3">
-                      <p className="type-body text-dark leading-relaxed">
-                        {item.answer}
-                      </p>
-                    </div>
-                  </AccordionContent>
-                </AccordionItem>
-              );
-            })}
-          </Accordion>
-        </div>
+                    &#x25BE;
+                  </span>
+                </AccordionTrigger>
+                <AccordionContent
+                  panelClassName="accordion-expand"
+                  className="overflow-hidden"
+                >
+                  <div
+                    className="pb-4 text-dark [&_p]:text-base [&_p]:leading-relaxed [&_p:not(:last-child)]:mb-3 [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-accent"
+                    dangerouslySetInnerHTML={{ __html: item.answer }}
+                  />
+                </AccordionContent>
+              </AccordionItem>
+            );
+          })}
+        </Accordion>
       </div>
     </section>
   );

--- a/src/app/about/QnaBlock.tsx
+++ b/src/app/about/QnaBlock.tsx
@@ -19,11 +19,9 @@ interface QnaItem {
 export default function QnaBlock({ items }: { items: QnaItem[] }) {
   const [openValue, setOpenValue] = useState<string[]>([]);
 
-  if (items.length === 0) return null;
-
   return (
-    <section id="q-and-a" className="px-5 py-12">
-      <div className="max-w-[1080px] mx-auto">
+    <section id="q-and-a" className="px-6 sm:px-16 py-16">
+      <div className="max-w-screen-2xl mx-auto">
         <SectionHeader label="Questions & Answers" />
         <div className="mt-4 border border-border-light">
           <Accordion value={openValue} onValueChange={setOpenValue}>

--- a/src/app/about/QuickLinks.tsx
+++ b/src/app/about/QuickLinks.tsx
@@ -5,8 +5,8 @@ interface QuickLink {
 
 export default function QuickLinks({ links }: { links: QuickLink[] }) {
   return (
-    <div className="px-5 border-b border-border-light overflow-x-auto scrollbar-none">
-      <div className="max-w-[1080px] mx-auto flex gap-6">
+    <div className="px-6 sm:px-16 border-b border-border-light overflow-x-auto scrollbar-none">
+      <div className="max-w-screen-2xl mx-auto flex gap-6">
         {links.map((link) => (
           <a
             key={link.href}

--- a/src/app/about/TeamBlock.tsx
+++ b/src/app/about/TeamBlock.tsx
@@ -1,4 +1,3 @@
-import { SectionHeader } from "@/components/ui/section-header";
 import { PersonCard } from "@/components/ui/person-card";
 import type { Person } from "./types";
 
@@ -10,10 +9,9 @@ const roleGroups = [
 
 export default function TeamBlock({ members }: { members: Person[] }) {
   return (
-    <section className="px-5 py-12 border-b border-border-light">
-      <div className="max-w-[1080px] mx-auto">
-        <SectionHeader label="Team" />
-        <div className="space-y-12">
+    <section className="px-6 sm:px-16 py-16 border-b border-border-light">
+      <div className="max-w-screen-2xl mx-auto">
+        <div className="space-y-16">
           {roleGroups.map(({ key, label, id }) => {
             const group = members
               .filter((m) => (m.role || "CORE") === key)
@@ -21,8 +19,8 @@ export default function TeamBlock({ members }: { members: Person[] }) {
             if (group.length === 0) return null;
             return (
               <div key={key} id={id}>
-                <h3 className="type-h4 text-dark mb-4">{label}</h3>
-                <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                <h3 className="type-h2 text-dark mb-12">{label}</h3>
+                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-8">
                   {group.map((m) => (
                     <PersonCard
                         key={m.id}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -36,8 +36,8 @@ export default async function AboutPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <section className="px-5 pt-[120px] pb-[100px] md:pt-[140px] md:pb-[120px] border-b border-border-light">
-        <div className="max-w-[1080px] mx-auto">
+      <section className="px-6 sm:px-16 pt-32 pb-10 sm:pb-16 border-b border-border-light">
+        <div className="max-w-screen-2xl mx-auto">
           <SectionLabel as="h2">Who We Are</SectionLabel>
           <h1 className="type-display mt-4 mb-6 text-dark" style={{ letterSpacing: "-0.126rem" }}>
             Canada is worth building.

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -12,7 +12,7 @@ const quickLinks = [
   { label: "Core Team", href: "#core-team" },
   { label: "Board", href: "#board" },
   { label: "Memo Authors", href: "#memo-authors" },
-  { label: "Q&A", href: "#q-and-a" },
+  { label: "FAQs", href: "#faqs" },
 ];
 
 export default async function AboutPage() {

--- a/src/components/ui/person-card.tsx
+++ b/src/components/ui/person-card.tsx
@@ -33,8 +33,8 @@ export function PersonCard({ name, title, photo, xUrl, linkedinUrl }: PersonCard
   const hasLinks = xUrl || linkedinUrl;
 
   return (
-    <div className="border border-border-light p-6 grid min-h-[160px] sm:min-h-[200px] lg:min-h-[240px] [grid-template-areas:'image_name_name''image_title_title''image_contacts_contacts'] [grid-template-columns:1fr_1fr_auto] [grid-template-rows:auto_auto_1fr]">
-      <div className="[grid-area:image] relative overflow-hidden border-r border-border-light -m-6 mr-6">
+    <div className="relative border border-border-light grid grid-cols-[7rem_1fr]">
+      <div className="relative overflow-hidden aspect-square">
         {photo ? (
           <Image
             src={photo}
@@ -47,42 +47,44 @@ export function PersonCard({ name, title, photo, xUrl, linkedinUrl }: PersonCard
           <MaplePlaceholder />
         )}
       </div>
-      <p className="type-h3 leading-tight [grid-area:name]">{name}</p>
-      {title && (
-        <p className="font-body text-[1.15rem] leading-[1.5] text-text-secondary mt-0.5 mb-5 [grid-area:title]">{title}</p>
-      )}
-      {hasLinks && (
-        <div className="flex items-end gap-1 [grid-area:contacts]">
-          {xUrl && (
-            <a
-              href={xUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="w-12 h-12 flex items-center justify-center border border-border-light hover:opacity-70 transition-opacity"
-            >
-              <Image
-                src="/assets/icons/platform-x-twitter.svg"
-                alt="X"
-                width={16}
-                height={16}
-                className="brightness-0 opacity-50"
-              />
-            </a>
-          )}
-          {linkedinUrl && (
-            <a
-              href={linkedinUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="w-12 h-12 flex items-center justify-center border border-border-light hover:opacity-70 transition-opacity"
-            >
-              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" className="opacity-50">
-                <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" fill="currentColor" />
-              </svg>
-            </a>
-          )}
-        </div>
-      )}
+      <div className="relative p-4">
+        <p className="type-h3 leading-tight">{name}</p>
+        {title && (
+          <p className="font-body text-[1.15rem] leading-[1.5] text-text-secondary mt-0.5">{title}</p>
+        )}
+        {hasLinks && (
+          <div className="absolute bottom-4 right-4 flex items-center gap-2">
+            {xUrl && (
+              <a
+                href={xUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center hover:opacity-70 transition-opacity"
+              >
+                <Image
+                  src="/assets/icons/platform-x-twitter.svg"
+                  alt="X"
+                  width={16}
+                  height={16}
+                  className="brightness-0 opacity-50"
+                />
+              </a>
+            )}
+            {linkedinUrl && (
+              <a
+                href={linkedinUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center justify-center hover:opacity-70 transition-opacity"
+              >
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" className="opacity-50">
+                  <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" fill="currentColor" />
+                </svg>
+              </a>
+            )}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/lib/api/team.ts
+++ b/src/lib/api/team.ts
@@ -2,10 +2,7 @@ import { apiFetch } from "./client";
 import type { YFTeamMember, YFListResponse } from "./types";
 
 const ROLE_MAP: Record<string, string> = {
-  team: "CORE",
   board: "BOARD",
-  advisor: "ADVISOR",
-  volunteer: "CORE",
   employee: "CORE",
   memo_author: "MEMO_AUTHOR",
 };
@@ -28,7 +25,7 @@ function mapTeamMember(m: YFTeamMember): TeamMemberSerialized {
     id: String(m.id),
     name: m.name,
     title: m.title,
-    role: ROLE_MAP[m.role] ?? "CORE",
+    role: ROLE_MAP[m.role] ?? "OTHER",
     photo: m.profile_photo_url,
     xUrl: m.twitter_url,
     linkedinUrl: m.linkedin_url,


### PR DESCRIPTION
## Summary
- Match IFP.org/about spacing and 3/2/1 team-card grid; flush card images; role-scoped team groups (employee → Core, memo_author → Memo Authors).
- Rewrite the FAQ block to match IFP: 2-col on desktop, 1-col mobile, horizontal dividers instead of card boxes, smaller question text, accent chevron.
- Answers pulled from `/api/v1/faqs` and rendered as HTML (Trix output) instead of escaped text.

## Test plan
- [ ] `/about` at ≥956px: 2-col FAQ grid, single 1px divider between stacked rows, `#faqs` anchor works from quick links.
- [ ] `/about` at <956px: single-column FAQ list.
- [ ] Each FAQ opens independently; opened row does not stretch its sibling row.
- [ ] Answer HTML renders (links visible, not literal `<p>` tags).
- [ ] Team grid: 3-col at xl, 2-col at sm, 1-col below; person card images flush with borders; social icons pinned bottom-right without stretching the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)