### PR TITLE
About page IFP-style refresh + Latest Pieces ContentCard refactor

### DIFF
--- a/src/app/about/QnaBlock.tsx
+++ b/src/app/about/QnaBlock.tsx
@@ -71,7 +71,7 @@ export default function QnaBlock({ items }: { items: QnaItem[] }) {
   );
 
   return (
-    <section id="faqs" className="px-6 sm:px-16 py-16">
+    <section id="faqs" className="px-6 sm:px-16 py-12">
       <div className="max-w-screen-2xl mx-auto">
         <SectionHeader label="FAQs" />
         <div className="mt-4 grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-start">

--- a/src/app/about/QnaBlock.tsx
+++ b/src/app/about/QnaBlock.tsx
@@ -18,56 +18,66 @@ interface QnaItem {
 export default function QnaBlock({ items }: { items: QnaItem[] }) {
   const [openValue, setOpenValue] = useState<string[]>([]);
 
+  const leftItems = items.filter((_, i) => i % 2 === 0);
+  const rightItems = items.filter((_, i) => i % 2 === 1);
+
+  const renderColumn = (column: { item: QnaItem; index: number }[]) => (
+    <Accordion
+      value={openValue}
+      onValueChange={setOpenValue}
+      className="flex flex-col"
+    >
+      {column.map(({ item, index }) => {
+        const value = `qna-${index}`;
+        const isOpen = openValue.includes(value);
+
+        return (
+          <AccordionItem
+            key={item.id}
+            value={value}
+            className="border-b border-border-light first:border-t"
+          >
+            <AccordionTrigger
+              className="[&_[data-slot=accordion-trigger-icon]]:hidden flex items-center justify-between cursor-pointer group w-full text-left py-4 transition-colors rounded-none border-transparent hover:no-underline [&]:bg-transparent"
+            >
+              <h3
+                className={`type-h4 transition-colors duration-200 ${
+                  isOpen ? "text-accent" : "text-dark group-hover:text-accent"
+                }`}
+              >
+                {item.question}
+              </h3>
+              <span
+                className={`shrink-0 ml-4 transition-transform duration-200 ${
+                  isOpen ? "text-accent rotate-180" : "text-accent"
+                }`}
+              >
+                &#x25BE;
+              </span>
+            </AccordionTrigger>
+            <AccordionContent
+              panelClassName="accordion-expand"
+              className="overflow-hidden"
+            >
+              <div
+                className="pb-4 text-dark [&_p]:text-base [&_p]:leading-relaxed [&_p:not(:last-child)]:mb-3 [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-accent"
+                dangerouslySetInnerHTML={{ __html: item.answer }}
+              />
+            </AccordionContent>
+          </AccordionItem>
+        );
+      })}
+    </Accordion>
+  );
+
   return (
     <section id="faqs" className="px-6 sm:px-16 py-16">
       <div className="max-w-screen-2xl mx-auto">
         <SectionHeader label="FAQs" />
-        <Accordion
-          value={openValue}
-          onValueChange={setOpenValue}
-          className="mt-4 grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-start"
-        >
-          {items.map((item, i) => {
-            const value = `qna-${i}`;
-            const isOpen = openValue.includes(value);
-
-            return (
-              <AccordionItem
-                key={item.id}
-                value={value}
-                className="border-b border-border-light first:border-t md:[&:nth-child(-n+2)]:border-t"
-              >
-                <AccordionTrigger
-                   className="[&_[data-slot=accordion-trigger-icon]]:hidden flex items-center justify-between cursor-pointer group w-full text-left py-4 transition-colors rounded-none border-transparent hover:no-underline [&]:bg-transparent"
-                >
-                  <h3
-                    className={`type-h4 transition-colors duration-200 ${
-                      isOpen ? "text-accent" : "text-dark group-hover:text-accent"
-                    }`}
-                  >
-                    {item.question}
-                  </h3>
-                  <span
-                    className={`shrink-0 ml-4 transition-transform duration-200 ${
-                      isOpen ? "text-accent rotate-180" : "text-accent"
-                    }`}
-                  >
-                    &#x25BE;
-                  </span>
-                </AccordionTrigger>
-                <AccordionContent
-                  panelClassName="accordion-expand"
-                  className="overflow-hidden"
-                >
-                  <div
-                    className="pb-4 text-dark [&_p]:text-base [&_p]:leading-relaxed [&_p:not(:last-child)]:mb-3 [&_a]:underline [&_a]:underline-offset-2 [&_a:hover]:text-accent"
-                    dangerouslySetInnerHTML={{ __html: item.answer }}
-                  />
-                </AccordionContent>
-              </AccordionItem>
-            );
-          })}
-        </Accordion>
+        <div className="mt-4 grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-start">
+          {renderColumn(leftItems.map((item, i) => ({ item, index: i * 2 })))}
+          {renderColumn(rightItems.map((item, i) => ({ item, index: i * 2 + 1 })))}
+        </div>
       </div>
     </section>
   );

--- a/src/app/about/TeamBlock.tsx
+++ b/src/app/about/TeamBlock.tsx
@@ -9,7 +9,7 @@ const roleGroups = [
 
 export default function TeamBlock({ members }: { members: Person[] }) {
   return (
-    <section className="px-6 sm:px-16 py-16 border-b border-border-light">
+    <section className="px-6 sm:px-16 py-12 border-b border-border-light">
       <div className="max-w-screen-2xl mx-auto">
         <div className="space-y-16">
           {roleGroups.map(({ key, label, id }) => {
@@ -20,7 +20,7 @@ export default function TeamBlock({ members }: { members: Person[] }) {
             return (
               <div key={key} id={id}>
                 <h3 className="type-h2 text-dark mb-12">{label}</h3>
-                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-8">
+                <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
                   {group.map((m) => (
                     <PersonCard
                         key={m.id}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -35,8 +35,8 @@ export default async function AboutPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <section className="px-6 sm:px-16 pt-32 pb-10 sm:pb-16 border-b border-border-light">
-        <div className="max-w-screen-2xl mx-auto grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-start">
-          <div className="md:pr-12 md:border-r md:border-border-light">
+        <div className="max-w-screen-2xl mx-auto grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-stretch">
+          <div className="md:pr-12 md:border-r md:border-border-light flex md:items-center">
             <h1 className="type-display text-dark" style={{ letterSpacing: "-0.126rem" }}>
               Canada can be the most prosperous country on earth
             </h1>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,6 +1,5 @@
 import { fetchFaqs, fetchTeamMembers, getSiteConfig } from "@/lib/api";
 import SectionLabel from "@/components/SectionLabel";
-import { Button } from "@/components/ui/button";
 import TeamBlock from "./TeamBlock";
 import QnaBlock from "./QnaBlock";
 import QuickLinks from "./QuickLinks";
@@ -37,17 +36,22 @@ export default async function AboutPage() {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
       <section className="px-6 sm:px-16 pt-32 pb-10 sm:pb-16 border-b border-border-light">
-        <div className="max-w-screen-2xl mx-auto">
-          <SectionLabel as="h2">Who We Are</SectionLabel>
-          <h1 className="type-display mt-4 mb-6 text-dark" style={{ letterSpacing: "-0.126rem" }}>
-            Canada is worth building.
-          </h1>
-          <p className="type-body max-w-[600px] text-dark/70">
-            Build Canada publishes bold policy research and builds transparency tools to make Canada the most prosperous country in the world.
-          </p>
-          <div className="flex flex-wrap gap-4 mt-6">
-            <Button href="/memos/build-canada-founding-memo">Read the Founding Memo</Button>
-            <Button href="#">Read our Constitution</Button>
+        <div className="max-w-screen-2xl mx-auto grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-start">
+          <div className="md:pr-12 md:border-r md:border-border-light">
+            <SectionLabel as="h2">About</SectionLabel>
+            <h1 className="type-display text-dark mt-4" style={{ letterSpacing: "-0.126rem" }}>
+              Canada can be the most prosperous country on earth.
+            </h1>
+          </div>
+          <div className="mt-6 md:mt-0">
+            <div className="type-body text-dark/70 space-y-4">
+              <p>
+                Canada isn&rsquo;t something we found. Nor was it something we were given. It was something that was built, by successive waves and generations of people with ideas, energy, and ambition for what this country could be. But in recent years that energy has been lost. At some point, we started to take Canada and our standard of living for granted. And now we are starting to feel the effects of lowered expectations.
+              </p>
+              <p>
+                We love this country. We believe we have the talent, resources, and potential to become the most prosperous country in the world. But we are not content to stand by and watch our nation&rsquo;s decline. We believe Canada can grow &ndash; fast and fearlessly.
+              </p>
+            </div>
           </div>
         </div>
       </section>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -38,7 +38,7 @@ export default async function AboutPage() {
         <div className="max-w-screen-2xl mx-auto grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-start">
           <div className="md:pr-12 md:border-r md:border-border-light">
             <h1 className="type-display text-dark" style={{ letterSpacing: "-0.126rem" }}>
-              Canada can be the most prosperous country on earth.
+              Canada can be the most prosperous country on earth
             </h1>
           </div>
           <div className="mt-6 md:mt-0">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,5 +1,4 @@
 import { fetchFaqs, fetchTeamMembers, getSiteConfig } from "@/lib/api";
-import SectionLabel from "@/components/SectionLabel";
 import TeamBlock from "./TeamBlock";
 import QnaBlock from "./QnaBlock";
 import QuickLinks from "./QuickLinks";
@@ -38,8 +37,7 @@ export default async function AboutPage() {
       <section className="px-6 sm:px-16 pt-32 pb-10 sm:pb-16 border-b border-border-light">
         <div className="max-w-screen-2xl mx-auto grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-start">
           <div className="md:pr-12 md:border-r md:border-border-light">
-            <SectionLabel as="h2">About</SectionLabel>
-            <h1 className="type-display text-dark mt-4" style={{ letterSpacing: "-0.126rem" }}>
+            <h1 className="type-display text-dark" style={{ letterSpacing: "-0.126rem" }}>
               Canada can be the most prosperous country on earth.
             </h1>
           </div>

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -34,7 +34,7 @@ export default async function AboutPage() {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <section className="px-6 sm:px-16 pt-32 pb-10 sm:pb-16 border-b border-border-light">
+      <section className="px-6 sm:px-16 py-12 border-b border-border-light">
         <div className="max-w-screen-2xl mx-auto grid grid-cols-1 md:grid-cols-2 md:gap-x-12 items-stretch">
           <div className="md:pr-12 md:border-r md:border-border-light flex md:items-center">
             <h1 className="type-display text-dark" style={{ letterSpacing: "-0.126rem" }}>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,14 +77,15 @@ html {
 
 .accordion-expand {
   display: grid;
-  grid-template-rows: 0fr;
-  transition: grid-template-rows 100ms ease-out, opacity 100ms ease-out;
-  opacity: 0;
-}
-
-.accordion-expand[data-open] {
   grid-template-rows: 1fr;
   opacity: 1;
+  transition: grid-template-rows 100ms ease-out, opacity 100ms ease-out;
+}
+
+.accordion-expand[data-starting-style],
+.accordion-expand[data-ending-style] {
+  grid-template-rows: 0fr;
+  opacity: 0;
 }
 
 .accordion-expand > div {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,7 +78,7 @@ html {
 .accordion-expand {
   display: grid;
   grid-template-rows: 0fr;
-  transition: grid-template-rows 200ms ease-out, opacity 200ms ease-out;
+  transition: grid-template-rows 100ms ease-out, opacity 100ms ease-out;
   opacity: 0;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,7 +78,7 @@ html {
 .accordion-expand {
   display: grid;
   grid-template-rows: 0fr;
-  transition: grid-template-rows 300ms ease-out, opacity 300ms ease-out;
+  transition: grid-template-rows 200ms ease-out, opacity 200ms ease-out;
   opacity: 0;
 }
 

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -21,14 +21,6 @@ function formatTime(iso: string, tz: string): string {
   });
 }
 
-function getUserTimeZone(): string {
-  try {
-    return Intl.DateTimeFormat().resolvedOptions().timeZone;
-  } catch {
-    return "America/New_York";
-  }
-}
-
 function formatAddress(event: LumaEvent): string | null {
   const addr = event.address;
   if (!addr) return null;
@@ -39,11 +31,8 @@ function formatAddress(event: LumaEvent): string | null {
 }
 
 export default function EventCard({ event }: { event: LumaEvent }) {
-  const userTz = getUserTimeZone();
   const eventDate = formatEventDate(event.startAt, event.timezone);
-  const userTime = formatTime(event.startAt, userTz);
   const eventLocalTime = formatTime(event.startAt, event.timezone);
-  const showUserTime = userTz !== event.timezone;
   const address = formatAddress(event);
   const hostNames = event.hosts
     .map((h) => h.name)
@@ -63,15 +52,10 @@ export default function EventCard({ event }: { event: LumaEvent }) {
         </div>
       )}
       <div className="flex-1 min-w-0 p-6">
-        <span className="type-label font-bold text-text-secondary block m-0 pb-1">{eventDate}</span>
-        <p className="type-caption mt-1">
-          {showUserTime ? (
-            <>
-              <span className="text-text-secondary">{userTime}</span>
-              <span className="text-text-secondary mx-1">·</span>
-            </>
-          ) : null}
-          <span className="text-accent">{eventLocalTime}</span>
+        <p className="type-label font-bold text-text-secondary m-0 pb-1">
+          <span>{eventDate}</span>
+          <span className="mx-1.5">·</span>
+          <span>{eventLocalTime}</span>
         </p>
         <a
           href={event.url}

--- a/src/components/FeedPreview.tsx
+++ b/src/components/FeedPreview.tsx
@@ -1,10 +1,19 @@
 import { fetchFeedPicks } from "@/lib/api";
-import { IGCard, XCard, TikTokCard, SubstackCard, FeedCard } from "@/components/feed";
+import {
+  IGCard,
+  XCard,
+  TikTokCard,
+  SubstackCard,
+  MemoCard,
+  BuilderCard,
+  BlogCard,
+  FeedCard,
+} from "@/components/feed";
 import { Button } from "@/components/ui/button";
 import { SectionHeader } from "@/components/ui/section-header";
 
 export default async function FeedPreview() {
-  const items = await fetchFeedPicks("x,substack,memo|blog|builder,x:canada_spends");
+  const items = await fetchFeedPicks("x,substack,blog|builder,x:canada_spends");
 
   return (
     <div className="flex flex-col">
@@ -18,19 +27,26 @@ export default async function FeedPreview() {
       />
       <div className="border-t border-l border-border-light grid grid-cols-1 cards:grid-cols-2">
         {items.length > 0
-          ? items.map((item) =>
-              item.type === "IG" ? (
-                <IGCard key={item.id} item={item} />
-              ) : item.type === "X" ? (
-                <XCard key={item.id} item={item} />
-              ) : item.type === "TIKTOK" ? (
-                <TikTokCard key={item.id} item={item} />
-              ) : item.type === "SUBSTACK" ? (
-                <SubstackCard key={item.id} item={item} />
-              ) : (
-                <FeedCard key={item.id} item={item} />
-              )
-            )
+          ? items.map((item) => {
+              switch (item.type) {
+                case "IG":
+                  return <IGCard key={item.id} item={item} />;
+                case "X":
+                  return <XCard key={item.id} item={item} />;
+                case "TIKTOK":
+                  return <TikTokCard key={item.id} item={item} />;
+                case "SUBSTACK":
+                  return <SubstackCard key={item.id} item={item} />;
+                case "MEMO":
+                  return <MemoCard key={item.id} item={item} />;
+                case "BUILDER":
+                  return <BuilderCard key={item.id} item={item} />;
+                case "BLOG":
+                  return <BlogCard key={item.id} item={item} />;
+                default:
+                  return <FeedCard key={item.id} item={item} />;
+              }
+            })
           : [1, 2, 3, 4].map((i) => (
               <div
                 key={i}

--- a/src/components/feed/BlogCard.tsx
+++ b/src/components/feed/BlogCard.tsx
@@ -1,0 +1,76 @@
+import Image from "next/image";
+import { ContentCard, type ContentCardTheme } from "./ContentCard";
+import { type FeedItem, feedImage, itemHref, stripHtml, formatFeedDate } from "./types";
+
+const THEME: ContentCardTheme = {
+  bg: "var(--color-bg)",
+  text: "var(--color-dark)",
+  muted: "var(--color-text-secondary)",
+  divider: "var(--color-border-light)",
+  ctaBorder: "var(--color-dark)",
+  ctaText: "var(--color-dark)",
+  ctaHoverBg: "var(--color-dark)",
+  ctaHoverText: "var(--color-bg)",
+  ctaHoverBorder: "var(--color-dark)",
+  titleHover: "var(--color-accent)",
+};
+
+const MUTED = "var(--color-text-secondary)";
+
+function BlogIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M4 5h16v14H4z"
+        stroke={MUTED}
+        strokeWidth="2"
+        fill="none"
+        strokeLinejoin="round"
+      />
+      <path d="M7 9h10M7 13h10M7 17h7" stroke={MUTED} strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function BlogCard({ item }: { item: FeedItem }) {
+  const img = feedImage(item);
+  const isLogo = img === "/assets/logos/logo-standard.svg";
+
+  return (
+    <ContentCard
+      href={itemHref(item)}
+      theme={THEME}
+      top={
+        <div className="relative h-[90px] bg-dark">
+          {img && (
+            <Image
+              src={img}
+              alt={item.title || ""}
+              fill
+              className={
+                isLogo
+                  ? "object-contain p-5 opacity-80 group-hover:opacity-95 transition-opacity"
+                  : "object-cover opacity-70 group-hover:opacity-85 transition-opacity"
+              }
+            />
+          )}
+        </div>
+      }
+      label={{ icon: <BlogIcon />, text: "Essay" }}
+      title={item.title}
+      body={
+        item.body ? (
+          <span style={{ color: "var(--color-text-secondary)" }}>
+            {stripHtml(item.body)}
+          </span>
+        ) : null
+      }
+      bodyClassName="line-clamp-2"
+      meta={item.createdAt ? formatFeedDate(item.createdAt) : null}
+      footer={{
+        brandIcon: <BlogIcon />,
+        ctaLabel: "Read more",
+      }}
+    />
+  );
+}

--- a/src/components/feed/BuilderCard.tsx
+++ b/src/components/feed/BuilderCard.tsx
@@ -1,0 +1,82 @@
+import Image from "next/image";
+import { ContentCard, type ContentCardTheme } from "./ContentCard";
+import { type FeedItem, feedImage, itemHref, formatFeedDate } from "./types";
+
+const THEME: ContentCardTheme = {
+  bg: "var(--color-bg)",
+  text: "var(--color-dark)",
+  muted: "var(--color-text-secondary)",
+  divider: "var(--color-border-light)",
+  ctaBorder: "var(--color-dark)",
+  ctaText: "var(--color-dark)",
+  ctaHoverBg: "var(--color-accent)",
+  ctaHoverText: "var(--color-bg)",
+  ctaHoverBorder: "var(--color-accent)",
+  titleHover: "var(--color-accent)",
+};
+
+const MUTED = "var(--color-text-secondary)";
+
+function BuilderIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M4 21V7l8-4 8 4v14"
+        stroke={MUTED}
+        strokeWidth="2"
+        fill="none"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M9 21v-6h6v6"
+        stroke={MUTED}
+        strokeWidth="2"
+        fill="none"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export function BuilderCard({ item }: { item: FeedItem }) {
+  const img = feedImage(item);
+  const isLogo = img === "/assets/logos/logo-standard.svg";
+
+  return (
+    <ContentCard
+      href={itemHref(item)}
+      theme={THEME}
+      top={
+        <div className="relative h-[90px] bg-dark">
+          {img && (
+            <Image
+              src={img}
+              alt={item.title || ""}
+              fill
+              className={
+                isLogo
+                  ? "object-contain p-5 opacity-80 group-hover:opacity-95 transition-opacity"
+                  : "object-cover opacity-70 group-hover:opacity-85 transition-opacity"
+              }
+            />
+          )}
+        </div>
+      }
+      label={{ icon: <BuilderIcon />, text: "Great Canadian Builder" }}
+      title={item.title}
+      body={
+        item.subtitle ? (
+          <span style={{ color: "var(--color-text-secondary)" }}>
+            {item.subtitle}
+          </span>
+        ) : null
+      }
+      bodyClassName="line-clamp-2"
+      meta={item.createdAt ? formatFeedDate(item.createdAt) : null}
+      footer={{
+        brandIcon: <BuilderIcon />,
+        ctaLabel: "Read profile",
+      }}
+    />
+  );
+}

--- a/src/components/feed/ContentCard.tsx
+++ b/src/components/feed/ContentCard.tsx
@@ -1,0 +1,119 @@
+import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+import { FeedChevron } from "./FeedChevron";
+
+export interface ContentCardTheme {
+  bg: string;
+  text: string;
+  muted: string;
+  divider: string;
+  ctaBorder: string;
+  ctaText: string;
+  ctaHoverBg: string;
+  ctaHoverText: string;
+  ctaHoverBorder?: string;
+  titleHover?: string;
+  ctaHoverClassName?: string;
+}
+
+export interface ContentCardProps {
+  href: string;
+  external?: boolean;
+  theme: ContentCardTheme;
+  top?: ReactNode;
+  label?: { icon?: ReactNode; text: string };
+  title?: string | null;
+  body?: ReactNode;
+  bodyClassName?: string;
+  meta?: string | null;
+  footer: { brandIcon: ReactNode; ctaLabel: string };
+}
+
+export function ContentCard({
+  href,
+  external,
+  theme,
+  top,
+  label,
+  title,
+  body,
+  bodyClassName,
+  meta,
+  footer,
+}: ContentCardProps) {
+  const ctaHoverBorder = theme.ctaHoverBorder ?? theme.ctaHoverBg;
+  const titleHover = theme.titleHover ?? theme.ctaHoverBg;
+
+  const cardStyle = {
+    backgroundColor: theme.bg,
+    ["--cc-title-hover" as string]: titleHover,
+    ["--cc-cta-hover-bg" as string]: theme.ctaHoverBg,
+    ["--cc-cta-hover-text" as string]: theme.ctaHoverText,
+    ["--cc-cta-hover-border" as string]: ctaHoverBorder,
+  } as CSSProperties;
+
+  return (
+    <Link
+      href={href}
+      target={external ? "_blank" : undefined}
+      rel={external ? "noopener noreferrer" : undefined}
+      className="border-b border-r border-border-light flex flex-col group overflow-hidden h-64"
+      style={cardStyle}
+    >
+      {top}
+
+      <div className="px-5 py-4 flex flex-col gap-2 flex-1 min-h-0">
+        {label && (
+          <span
+            className="inline-flex items-center gap-1.5 text-[11px] uppercase tracking-[0.08em] font-medium"
+            style={{ color: theme.muted }}
+          >
+            {label.icon}
+            {label.text}
+          </span>
+        )}
+
+        {title && (
+          <h3
+            className="type-h4 transition-colors group-hover:text-[color:var(--cc-title-hover)]"
+            style={{ color: theme.text }}
+          >
+            {title}
+          </h3>
+        )}
+
+        {body && (
+          <div
+            className={`type-default ${bodyClassName ?? "line-clamp-4"}`}
+            style={{ color: theme.text }}
+          >
+            {body}
+          </div>
+        )}
+
+        {meta && (
+          <span className="type-mono-sm mt-auto" style={{ color: theme.muted }}>
+            {meta}
+          </span>
+        )}
+      </div>
+
+      <div
+        className="px-5 py-3 flex items-center justify-between border-t"
+        style={{ borderColor: theme.divider }}
+      >
+        {footer.brandIcon}
+        <span
+          className={`inline-flex items-center gap-2 type-label px-3 py-1 border transition-all group-hover:bg-[color:var(--cc-cta-hover-bg)] group-hover:text-[color:var(--cc-cta-hover-text)] group-hover:border-[color:var(--cc-cta-hover-border)] ${theme.ctaHoverClassName ?? ""}`}
+          style={{
+            borderColor: theme.ctaBorder,
+            color: theme.ctaText,
+          }}
+        >
+          {footer.ctaLabel}
+          <FeedChevron />
+        </span>
+      </div>
+    </Link>
+  );
+}

--- a/src/components/feed/IGCard.tsx
+++ b/src/components/feed/IGCard.tsx
@@ -1,83 +1,101 @@
-import Link from "next/link";
 import Image from "next/image";
-import { type FeedItem, isIGVideo } from "./types";
+import { ContentCard, type ContentCardTheme } from "./ContentCard";
 import { SocialCardHeader } from "./SocialCardHeader";
-import { FeedChevron } from "./FeedChevron";
+import { type FeedItem, isIGVideo } from "./types";
 
-const COLORS = {
-  border: "#dbdbdb",
-  headerBorder: "#efefef",
-  avatarBorder: "var(--color-accent)",
+const THEME: ContentCardTheme = {
+  bg: "#ffffff",
   text: "#262626",
   muted: "#8e8e8e",
-  bg: "white",
+  divider: "#efefef",
+  ctaBorder: "#262626",
+  ctaText: "#262626",
+  ctaHoverBg: "#C13584",
+  ctaHoverText: "#ffffff",
+  ctaHoverBorder: "transparent",
+  titleHover: "#C13584",
+  ctaHoverClassName:
+    "group-hover:bg-gradient-to-r group-hover:from-[#833AB4] group-hover:via-[#C13584] group-hover:to-[#F77737]",
 };
 
 export function IGCard({ item }: { item: FeedItem }) {
+  const video = isIGVideo(item);
+
   return (
-    <Link
+    <ContentCard
       href={item.url || "/content"}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="border-b border-r border-border-light flex flex-col group overflow-hidden h-64"
-      style={{ backgroundColor: COLORS.bg }}
-    >
-      <SocialCardHeader
-        item={item}
-        platformIcon="/assets/icons/platform-instagram.svg"
-        platformAlt="Instagram"
-        borderColor={COLORS.headerBorder}
-        textColor={COLORS.text}
-        mutedColor={COLORS.muted}
-        avatarBorder={COLORS.avatarBorder}
-      />
-
-      <div className="px-5 py-4 flex flex-col gap-2 flex-1">
-        <span
-          className="inline-flex items-center gap-1 text-[11px] uppercase tracking-[0.08em] font-medium"
-          style={{ color: COLORS.muted }}
-        >
-          {isIGVideo(item) ? (
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none">
-              <path d="M8 5.14v13.72a1 1 0 001.5.86l11.24-6.86a1 1 0 000-1.72L9.5 4.28A1 1 0 008 5.14z" fill={COLORS.muted} />
-            </svg>
-          ) : (
-            <svg width="10" height="10" viewBox="0 0 24 24" fill="none">
-              <rect x="3" y="3" width="18" height="18" rx="2" stroke={COLORS.muted} strokeWidth="2" fill="none" />
-              <circle cx="8.5" cy="8.5" r="1.5" fill={COLORS.muted} />
-              <path d="M21 15l-5-5L5 21" stroke={COLORS.muted} strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" fill="none" />
-            </svg>
-          )}
-          {isIGVideo(item) ? "Video" : "Photo"}
-        </span>
-
-        {item.body && (
-          <p className="type-default line-clamp-4 whitespace-pre-line" style={{ color: COLORS.text }}>
-            <span className="font-display font-medium" style={{ letterSpacing: "-0.02em" }}>
+      external
+      theme={THEME}
+      top={
+        <SocialCardHeader
+          item={item}
+          platformIcon="/assets/icons/platform-instagram.svg"
+          platformAlt="Instagram"
+          borderColor={THEME.divider}
+          textColor={THEME.text}
+          mutedColor={THEME.muted}
+          avatarBorder="var(--color-accent)"
+        />
+      }
+      label={{
+        icon: video ? (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M8 5.14v13.72a1 1 0 001.5.86l11.24-6.86a1 1 0 000-1.72L9.5 4.28A1 1 0 008 5.14z"
+              fill={THEME.muted}
+            />
+          </svg>
+        ) : (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none">
+            <rect
+              x="3"
+              y="3"
+              width="18"
+              height="18"
+              rx="2"
+              stroke={THEME.muted}
+              strokeWidth="2"
+              fill="none"
+            />
+            <circle cx="8.5" cy="8.5" r="1.5" fill={THEME.muted} />
+            <path
+              d="M21 15l-5-5L5 21"
+              stroke={THEME.muted}
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              fill="none"
+            />
+          </svg>
+        ),
+        text: video ? "Video" : "Photo",
+      }}
+      body={
+        item.body ? (
+          <p className="line-clamp-4 whitespace-pre-line">
+            <span
+              className="font-display font-medium"
+              style={{ letterSpacing: "-0.02em" }}
+            >
               @build_canada
             </span>{" "}
             {item.body}
           </p>
-        )}
-      </div>
-
-      <div
-        className="px-5 py-3 flex items-center justify-between border-t"
-        style={{ borderColor: COLORS.headerBorder }}
-      >
-        <Image
-          src="/assets/icons/platform-instagram.svg"
-          alt="Instagram"
-          width={16}
-          height={16}
-          className="brightness-0 opacity-30"
-          unoptimized
-        />
-        <span className="inline-flex items-center gap-2 type-label px-3 py-1 border border-[#262626] text-[#262626] bg-white group-hover:border-transparent group-hover:text-white group-hover:bg-gradient-to-r group-hover:from-[#833AB4] group-hover:via-[#C13584] group-hover:to-[#F77737] transition-all">
-          See post
-          <FeedChevron />
-        </span>
-      </div>
-    </Link>
+        ) : null
+      }
+      footer={{
+        brandIcon: (
+          <Image
+            src="/assets/icons/platform-instagram.svg"
+            alt="Instagram"
+            width={16}
+            height={16}
+            className="brightness-0 opacity-30"
+            unoptimized
+          />
+        ),
+        ctaLabel: "See post",
+      }}
+    />
   );
 }

--- a/src/components/feed/MemoCard.tsx
+++ b/src/components/feed/MemoCard.tsx
@@ -1,0 +1,77 @@
+import Image from "next/image";
+import { ContentCard, type ContentCardTheme } from "./ContentCard";
+import { type FeedItem, feedImage, itemHref, stripHtml, formatFeedDate } from "./types";
+
+const THEME: ContentCardTheme = {
+  bg: "var(--color-bg)",
+  text: "var(--color-dark)",
+  muted: "var(--color-text-secondary)",
+  divider: "var(--color-border-light)",
+  ctaBorder: "var(--color-dark)",
+  ctaText: "var(--color-dark)",
+  ctaHoverBg: "var(--color-dark)",
+  ctaHoverText: "var(--color-bg)",
+  ctaHoverBorder: "var(--color-dark)",
+  titleHover: "var(--color-accent)",
+};
+
+const MUTED = "var(--color-text-secondary)";
+
+function MemoIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none">
+      <path
+        d="M6 3h9l4 4v14H6z"
+        stroke={MUTED}
+        strokeWidth="2"
+        fill="none"
+        strokeLinejoin="round"
+      />
+      <path d="M14 3v5h5" stroke={MUTED} strokeWidth="2" fill="none" strokeLinejoin="round" />
+      <path d="M9 13h7M9 17h5" stroke={MUTED} strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+export function MemoCard({ item }: { item: FeedItem }) {
+  const img = feedImage(item);
+  const isLogo = img === "/assets/logos/logo-standard.svg";
+
+  return (
+    <ContentCard
+      href={itemHref(item)}
+      theme={THEME}
+      top={
+        <div className="relative h-[90px] bg-dark">
+          {img && (
+            <Image
+              src={img}
+              alt={item.title || ""}
+              fill
+              className={
+                isLogo
+                  ? "object-contain p-5 opacity-80 group-hover:opacity-95 transition-opacity"
+                  : "object-cover opacity-70 group-hover:opacity-85 transition-opacity"
+              }
+            />
+          )}
+        </div>
+      }
+      label={{ icon: <MemoIcon />, text: "Memo" }}
+      title={item.title}
+      body={
+        item.body ? (
+          <span style={{ color: "var(--color-text-secondary)" }}>
+            {stripHtml(item.body)}
+          </span>
+        ) : null
+      }
+      bodyClassName="line-clamp-2"
+      meta={item.createdAt ? formatFeedDate(item.createdAt) : null}
+      footer={{
+        brandIcon: <MemoIcon />,
+        ctaLabel: "Read memo",
+      }}
+    />
+  );
+}

--- a/src/components/feed/SubstackCard.tsx
+++ b/src/components/feed/SubstackCard.tsx
@@ -1,67 +1,60 @@
-import Link from "next/link";
 import Image from "next/image";
+import { ContentCard, type ContentCardTheme } from "./ContentCard";
 import { type FeedItem, isValidImage, formatFeedDate } from "./types";
-import { FeedChevron } from "./FeedChevron";
+
+const THEME: ContentCardTheme = {
+  bg: "#fffdf7",
+  text: "#1a1a1a",
+  muted: "#857e71",
+  divider: "#e8e2d9",
+  ctaBorder: "#1a1a1a",
+  ctaText: "#1a1a1a",
+  ctaHoverBg: "#FF6719",
+  ctaHoverText: "#ffffff",
+  ctaHoverBorder: "#FF6719",
+};
+
+function SubstackIcon({ size, opacity }: { size: number; opacity: number }) {
+  return (
+    <Image
+      src="/assets/icons/substack-icon.svg"
+      alt="Substack"
+      width={size}
+      height={size}
+      style={{ opacity }}
+      unoptimized
+    />
+  );
+}
 
 export function SubstackCard({ item }: { item: FeedItem }) {
   return (
-    <Link
+    <ContentCard
       href={item.url || "/content"}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="border-b border-r border-border-light bg-[#fffdf7] flex flex-col group overflow-hidden h-64"
-    >
-      {isValidImage(item.image) && (
-        <div className="relative h-[90px] bg-[#f7f5ef]">
-          <Image
-            src={item.image!}
-            alt={item.title || ""}
-            fill
-            className="object-cover opacity-85 group-hover:opacity-100 transition-opacity"
-          />
-        </div>
-      )}
-
-      <div className="px-5 py-4 flex flex-col gap-2 flex-1">
-        <div className="flex items-center gap-1.5">
-          <Image
-            src="/assets/icons/substack-icon.svg"
-            alt="Substack"
-            width={12}
-            height={12}
-            className="opacity-60"
-            unoptimized
-          />
-          <span className="text-[11px] uppercase tracking-[0.08em] font-medium text-[#857e71]">
-            Weekly Newsletter
-          </span>
-        </div>
-
-        {item.title && (
-          <h3 className="type-h4 text-[#1a1a1a] group-hover:text-[#FF6719] transition-colors">
-            {item.title}
-          </h3>
-        )}
-
-        <span className="type-mono-sm text-[#857e71]">
-          {formatFeedDate(item.createdAt)}
-        </span>
-      </div>
-
-      <div className="px-5 py-3 flex items-center justify-between border-t border-[#e8e2d9]">
-        <Image
-          src="/assets/icons/substack-icon.svg"
-          alt="Substack"
-          width={16}
-          height={16}
-          className="opacity-25"
-          unoptimized
-        />
-        <span className="inline-flex items-center gap-2 type-label px-3 py-1 border border-[#1a1a1a] text-[#1a1a1a] bg-[#fffdf7] group-hover:border-[#FF6719] group-hover:bg-[#FF6719] group-hover:text-white transition-all">
-          Read
-          <FeedChevron />
-        </span>
-      </div>
-    </Link>
+      external
+      theme={THEME}
+      top={
+        isValidImage(item.image) ? (
+          <div className="relative h-[90px]" style={{ backgroundColor: "#f7f5ef" }}>
+            <Image
+              src={item.image!}
+              alt={item.title || ""}
+              fill
+              className="object-cover opacity-85 group-hover:opacity-100 transition-opacity"
+            />
+          </div>
+        ) : null
+      }
+      label={{
+        icon: <SubstackIcon size={12} opacity={0.6} />,
+        text: "Weekly Newsletter",
+      }}
+      title={item.title}
+      meta={formatFeedDate(item.createdAt)}
+      footer={{
+        brandIcon: <SubstackIcon size={16} opacity={0.25} />,
+        ctaLabel: "Read",
+      }}
+    />
   );
 }

--- a/src/components/feed/TikTokCard.tsx
+++ b/src/components/feed/TikTokCard.tsx
@@ -1,65 +1,66 @@
-import Link from "next/link";
 import Image from "next/image";
-import { type FeedItem } from "./types";
+import { ContentCard, type ContentCardTheme } from "./ContentCard";
 import { SocialCardHeader } from "./SocialCardHeader";
-import { FeedChevron } from "./FeedChevron";
+import { type FeedItem } from "./types";
 
-const COLORS = {
-  border: "#2f2f2f",
-  headerBorder: "#2f2f2f",
-  avatarBorder: "#333",
+const THEME: ContentCardTheme = {
+  bg: "#121212",
   text: "#e1e1e2",
   muted: "#8a8b91",
-  bg: "#121212",
+  divider: "#2f2f2f",
+  ctaBorder: "#444444",
+  ctaText: "#e1e1e2",
+  ctaHoverBg: "#fe2c55",
+  ctaHoverText: "#ffffff",
+  ctaHoverBorder: "#fe2c55",
 };
 
 export function TikTokCard({ item }: { item: FeedItem }) {
   return (
-    <Link
+    <ContentCard
       href={item.url || "/content"}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="border-b border-r border-border-light bg-[#121212] flex flex-col group overflow-hidden h-64"
-    >
-      <SocialCardHeader
-        item={item}
-        platformIcon="/assets/icons/platform-tiktok.svg"
-        platformAlt="TikTok"
-        borderColor={COLORS.headerBorder}
-        textColor={COLORS.text}
-        mutedColor={COLORS.muted}
-        avatarBorder={COLORS.avatarBorder}
-      />
-
-      <div className="px-5 py-4 flex flex-col gap-2 flex-1">
-        <span className="inline-flex items-center gap-1 text-[11px] uppercase tracking-[0.08em] font-medium text-[#8a8b91]">
-          <svg width="10" height="10" viewBox="0 0 24 24" fill="none">
-            <path d="M8 5.14v13.72a1 1 0 001.5.86l11.24-6.86a1 1 0 000-1.72L9.5 4.28A1 1 0 008 5.14z" fill="#8a8b91" />
-          </svg>
-          Video
-        </span>
-
-        {item.body && (
-          <p className="type-default text-[#e1e1e2] line-clamp-4 whitespace-pre-line">
-            {item.body}
-          </p>
-        )}
-      </div>
-
-      <div className="px-5 py-3 flex items-center justify-between border-t border-[#2f2f2f]">
-        <Image
-          src="/assets/icons/platform-tiktok.svg"
-          alt="TikTok"
-          width={16}
-          height={16}
-          className="opacity-20"
-          unoptimized
+      external
+      theme={THEME}
+      top={
+        <SocialCardHeader
+          item={item}
+          platformIcon="/assets/icons/platform-tiktok.svg"
+          platformAlt="TikTok"
+          borderColor={THEME.divider}
+          textColor={THEME.text}
+          mutedColor={THEME.muted}
+          avatarBorder="#333"
         />
-        <span className="inline-flex items-center gap-2 type-label px-3 py-1 border border-[#444] text-[#e1e1e2] group-hover:border-[#fe2c55] group-hover:bg-[#fe2c55] group-hover:text-white transition-all">
-          See post
-          <FeedChevron />
-        </span>
-      </div>
-    </Link>
+      }
+      label={{
+        icon: (
+          <svg width="10" height="10" viewBox="0 0 24 24" fill="none">
+            <path
+              d="M8 5.14v13.72a1 1 0 001.5.86l11.24-6.86a1 1 0 000-1.72L9.5 4.28A1 1 0 008 5.14z"
+              fill={THEME.muted}
+            />
+          </svg>
+        ),
+        text: "Video",
+      }}
+      body={
+        item.body ? (
+          <p className="line-clamp-4 whitespace-pre-line">{item.body}</p>
+        ) : null
+      }
+      footer={{
+        brandIcon: (
+          <Image
+            src="/assets/icons/platform-tiktok.svg"
+            alt="TikTok"
+            width={16}
+            height={16}
+            className="opacity-20"
+            unoptimized
+          />
+        ),
+        ctaLabel: "See post",
+      }}
+    />
   );
 }

--- a/src/components/feed/XCard.tsx
+++ b/src/components/feed/XCard.tsx
@@ -1,66 +1,60 @@
-import Link from "next/link";
 import Image from "next/image";
-import { type FeedItem } from "./types";
+import { ContentCard, type ContentCardTheme } from "./ContentCard";
 import { SocialCardHeader } from "./SocialCardHeader";
-import { FeedChevron } from "./FeedChevron";
+import { type FeedItem } from "./types";
 
-const COLORS = {
-  border: "#2f3336",
-  headerBorder: "#2f3336",
-  avatarBorder: "#333",
+const THEME: ContentCardTheme = {
+  bg: "#000000",
   text: "#e7e9ea",
   muted: "#71767b",
-  bg: "black",
-  buttonBorder: "#536471",
+  divider: "#2f3336",
+  ctaBorder: "#536471",
+  ctaText: "#e7e9ea",
+  ctaHoverBg: "#1d9bf0",
+  ctaHoverText: "#ffffff",
+  ctaHoverBorder: "#1d9bf0",
 };
 
 export function XCard({ item }: { item: FeedItem }) {
   return (
-    <Link
+    <ContentCard
       href={item.url || "/content"}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="border-b border-r border-border-light bg-black flex flex-col group overflow-hidden h-64"
-    >
-      <SocialCardHeader
-        item={item}
-        platformIcon="/assets/icons/platform-x-twitter.svg"
-        platformAlt="X"
-        borderColor={COLORS.headerBorder}
-        textColor={COLORS.text}
-        mutedColor={COLORS.muted}
-        avatarBorder={COLORS.avatarBorder}
-      />
-
-      <div className="px-5 py-4 flex flex-col gap-2 flex-1">
-        <span className="inline-flex items-center gap-1 text-[11px] uppercase tracking-[0.08em] font-medium text-[#71767b]">
-          <svg width="10" height="10" viewBox="0 0 24 24" fill="none">
-            <path d="M4 4h16v12H5.17L4 17.17V4z" stroke="#71767b" strokeWidth="2" fill="none" strokeLinejoin="round" />
-          </svg>
-          Post
-        </span>
-
-        {item.body && (
-          <p className="type-default text-[#e7e9ea] line-clamp-4 whitespace-pre-line">
+      external
+      theme={THEME}
+      top={
+        <SocialCardHeader
+          item={item}
+          platformIcon="/assets/icons/platform-x-twitter.svg"
+          platformAlt="X"
+          borderColor={THEME.divider}
+          textColor={THEME.text}
+          mutedColor={THEME.muted}
+          avatarBorder="#333"
+        />
+      }
+      body={
+        item.body ? (
+          <p
+            className="font-display font-medium line-clamp-4 whitespace-pre-line"
+            style={{ letterSpacing: "-0.02em" }}
+          >
             {item.body}
           </p>
-        )}
-      </div>
-
-      <div className="px-5 py-3 flex items-center justify-between border-t border-[#2f3336]">
-        <Image
-          src="/assets/icons/platform-x-twitter.svg"
-          alt="X"
-          width={16}
-          height={16}
-          className="opacity-20"
-          unoptimized
-        />
-        <span className="inline-flex items-center gap-2 type-label px-3 py-1 border border-[#536471] text-[#e7e9ea] group-hover:border-[#1d9bf0] group-hover:bg-[#1d9bf0] group-hover:text-white transition-all">
-          See post
-          <FeedChevron />
-        </span>
-      </div>
-    </Link>
+        ) : null
+      }
+      footer={{
+        brandIcon: (
+          <Image
+            src="/assets/icons/platform-x-twitter.svg"
+            alt="X"
+            width={16}
+            height={16}
+            className="opacity-20"
+            unoptimized
+          />
+        ),
+        ctaLabel: "See post",
+      }}
+    />
   );
 }

--- a/src/components/feed/index.ts
+++ b/src/components/feed/index.ts
@@ -1,6 +1,11 @@
+export { ContentCard } from "./ContentCard";
+export type { ContentCardTheme, ContentCardProps } from "./ContentCard";
 export { IGCard } from "./IGCard";
 export { XCard } from "./XCard";
 export { TikTokCard } from "./TikTokCard";
 export { SubstackCard } from "./SubstackCard";
+export { MemoCard } from "./MemoCard";
+export { BuilderCard } from "./BuilderCard";
+export { BlogCard } from "./BlogCard";
 export { FeedCard } from "./FeedCard";
 export type { FeedItem } from "./types";

--- a/src/constants/nav-links.ts
+++ b/src/constants/nav-links.ts
@@ -9,6 +9,6 @@ export const NAV_LINKS: NavLink[] = [
   { label: "Memos", href: "/memos" },
   { label: "Content", href: "/content" },
   { label: "Projects", href: "/projects" },
-  { label: "About Us", href: "/about" },
+  { label: "About", href: "/about" },
   { label: "Shop", href: "https://shop.buildcanada.com", external: true },
 ];


### PR DESCRIPTION
## Summary

Two areas of work accumulated on this branch:

**About page (IFP-style)** — hero switched to 2-col layout, nav renamed to About, FAQs split into independent column accordions with base-ui transition hooks driving the open/close animation, section padding tightened, team grid 2-col breakpoint delayed.

**Latest Pieces feed cards** — extracted a shared `ContentCard` from the Substack layout so every feed card (Substack, X, IG, TikTok, plus new Memo / Builder / Blog derivatives) uses the same proportions and differs only in branding. The generic `FeedCard` fallback is replaced by dedicated derivatives for internal content types.

**Event cards** — date and event time now render on a single `type-label` line separated by a bullet; user-local time dropped.

## Test plan

- [ ] `/about` — verify hero layout, FAQ open/close animation, team grid breakpoints
- [ ] `/` (home) — "Latest Pieces" grid renders Substack, X, IG, TikTok, Memo, Builder, Blog cards with identical dimensions and distinct branding; hover states on title + CTA pill work per brand
- [ ] `/` — events timeline shows `Date · Time` inline in the same style
- [ ] Click-throughs: Substack/X/IG/TikTok open in new tabs; Memo/Builder/Blog use internal routes
- [ ] `pnpm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)