### PR TITLE
prelaunch: error boundaries, OG/canonical/metadata coverage, env cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,33 @@ npm run dev
 
 Requires a `.env` file with `DATABASE_URL` (defaults to `file:./dev.db`).
 
+## Environment variables
+
+Required in production:
+
+| Variable | Purpose | Notes |
+|----------|---------|-------|
+| `NEXT_PUBLIC_SITE_URL` | Canonical/OG/sitemap base URL | e.g. `https://buildcanada.com`. Used by `layout.tsx`, `sitemap.ts`, `robots.ts`, `lib/api/config.ts`, and JSON-LD. |
+| `NEXT_PUBLIC_TRACKER_API_BASE` | Backend host for `/tracker/api/*` rewrites | Set to wherever the Outcomes Tracker API is served. Falls back to `https://www.buildcanada.com`, which will loop after cutover. |
+| `YORK_FACTORY_API_URL` | York Factory CMS base URL | Defaults to `https://yorkfactory.buildcanada.com/api/v1`. Override per environment. |
+| `LUMA_API_KEY` | Luma events list (`/api/events`) | Without this the homepage events list silently returns empty. |
+
+Recommended:
+
+| Variable | Purpose |
+|----------|---------|
+| `NEXT_PUBLIC_POSTHOG_TOKEN` | PostHog analytics + client-side exception capture (`error.tsx` boundaries report here). |
+| `NEXT_PUBLIC_POSTHOG_HOST` | PostHog UI host. Defaults to `https://us.i.posthog.com`. |
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Google Analytics. Loader is conditional — omit to disable. |
+| `TRACKER_API_BASE` | Server-only override for tracker API base (read in `lib/tracker-api.ts` when no public var is set). |
+
+## Deployment notes
+
+- Set the env vars above before building. Several are baked into the static output (`NEXT_PUBLIC_*`), so a redeploy is required to change them.
+- After cutover, verify `/sitemap.xml` and `/robots.txt` reference the production domain.
+- Verify `/tracker` loads — if the API base is misconfigured it will silently fail to render data.
+- Cloudflare-proxied projects (e.g. `/exit-tax-calculator`, `/bills`) are not served by Next; ensure their proxy rules survive any DNS / origin change.
+
 ## Design
 
 Custom fonts: **Söhne** (headings), **Financier Text** (body), **Founders Grotesk Mono** (labels/buttons).

--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -5,5 +5,6 @@ if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_TOKEN) {
     api_host: "/ph",
     ui_host: process.env.NEXT_PUBLIC_POSTHOG_HOST || "https://us.i.posthog.com",
     defaults: "2026-01-30",
+    capture_exceptions: true,
   });
 }

--- a/src/app/about/layout.tsx
+++ b/src/app/about/layout.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: "About",
   description:
     "Build Canada exists to platform the bold — individuals, ideas, and reforms — that can push our country to new frontiers.",
+  alternates: { canonical: "/about" },
   openGraph: {
     title: "About",
     description:

--- a/src/app/builders/[slug]/page.tsx
+++ b/src/app/builders/[slug]/page.tsx
@@ -15,6 +15,7 @@ export async function generateMetadata({
     return {
       title: `${builder.name}: ${builder.tagline}`,
       description: builder.quote ?? undefined,
+      alternates: { canonical: `/builders/${slug}` },
       openGraph: {
         title: `${builder.name}: ${builder.tagline} | Build Canada`,
         description: builder.quote ?? undefined,

--- a/src/app/builders/opengraph-image.tsx
+++ b/src/app/builders/opengraph-image.tsx
@@ -1,0 +1,16 @@
+import { ImageResponse } from "next/og";
+import { BuildCanadaOGImage } from "@/lib/og-image-template";
+
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function Image() {
+  return new ImageResponse(
+    <BuildCanadaOGImage
+      title="Great Canadian Builders"
+      description="Short stories celebrating the incredible builders who shaped Canada."
+      label="Builders"
+    />,
+    { ...size },
+  );
+}

--- a/src/app/builders/page.tsx
+++ b/src/app/builders/page.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   title: "Great Canadian Builders",
   description:
     "Short stories celebrating the incredible builders who shaped Canada.",
+  alternates: { canonical: "/builders" },
 };
 
 export default async function BuildersPage() {

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+import { Button } from "@/components/ui/button";
+
+export default function Error({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_TOKEN) {
+      posthog.captureException(error, {
+        digest: error.digest,
+        pathname: window.location.pathname,
+        boundary: "app",
+      });
+    }
+  }, [error]);
+
+  return (
+    <div className="mx-[10px] my-[10px] border border-border-light bg-bg min-h-[calc(100vh-40px)] flex flex-col items-center justify-center relative overflow-hidden">
+      <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+        <div
+          className="absolute top-0 bottom-0 left-[6.7%] w-px"
+          style={{ backgroundColor: "var(--color-charcoal-1000)", opacity: 0.06 }}
+        />
+        <div
+          className="absolute top-0 bottom-0 left-[33.3%] w-px"
+          style={{ backgroundColor: "var(--color-charcoal-1000)", opacity: 0.06 }}
+        />
+        <div
+          className="absolute top-0 bottom-0 left-[50%] w-px"
+          style={{ backgroundColor: "var(--color-charcoal-1000)", opacity: 0.08 }}
+        />
+        <div
+          className="absolute top-0 bottom-0 right-[33.3%] w-px"
+          style={{ backgroundColor: "var(--color-charcoal-1000)", opacity: 0.06 }}
+        />
+        <div
+          className="absolute top-0 bottom-0 right-[6.7%] w-px"
+          style={{ backgroundColor: "var(--color-charcoal-1000)", opacity: 0.06 }}
+        />
+        <div
+          className="absolute left-0 right-0 top-[20%] h-px"
+          style={{ backgroundColor: "var(--color-charcoal-1000)", opacity: 0.06 }}
+        />
+        <div
+          className="absolute left-0 right-0 top-[50%] h-px"
+          style={{ backgroundColor: "var(--color-charcoal-1000)", opacity: 0.08 }}
+        />
+        <div
+          className="absolute left-0 right-0 top-[80%] h-px"
+          style={{ backgroundColor: "var(--color-charcoal-1000)", opacity: 0.06 }}
+        />
+        <div
+          className="absolute left-[6.7%] right-[6.7%] top-[50%] h-[2px]"
+          style={{ backgroundColor: "var(--color-auburn-800)", opacity: 0.25 }}
+        />
+      </div>
+
+      <div className="relative z-10 flex flex-col items-center text-center px-5">
+        <span
+          className="block select-none"
+          style={{
+            fontFamily: "var(--font-display)",
+            fontWeight: 500,
+            fontSize: "clamp(8rem, 22vw, 16rem)",
+            lineHeight: 0.85,
+            letterSpacing: "-0.04em",
+            color: "var(--color-charcoal-1000)",
+            opacity: 0.07,
+            fontVariantNumeric: "tabular-nums",
+          }}
+          aria-hidden="true"
+        >
+          500
+        </span>
+
+        <span className="type-label text-accent mb-4 tracking-[0.2em]">
+          Something Broke
+        </span>
+
+        <h1
+          className="type-display-sm mb-4"
+          style={{ color: "var(--color-charcoal-1000)" }}
+        >
+          A beam came loose.
+        </h1>
+
+        <p
+          className="type-body-sm mb-10 max-w-[420px]"
+          style={{ color: "var(--color-charcoal-600)" }}
+        >
+          Something went wrong on our end. We&apos;ve been notified and are on
+          it. Try again, or head back to the home page.
+        </p>
+
+        <div className="flex items-center gap-3">
+          <Button as="button" onClick={reset} variant="charcoal">
+            Try Again
+          </Button>
+          <Button as="link" href="/" variant="ghost">
+            Back to Home
+          </Button>
+        </div>
+      </div>
+
+      <div
+        className="absolute bottom-4 right-5 type-mono-sm pointer-events-none"
+        style={{ color: "var(--color-charcoal-300)", opacity: 0.5 }}
+        aria-hidden="true"
+      >
+        {error.digest ? `ERR.${error.digest.slice(0, 6).toUpperCase()}` : "ERR.500"}
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
     template: "%s | Build Canada",
   },
   description:
-    "Canada's Voice for Builders. Bold thinking from builders, reformers, and leaders pushing Canada to new frontiers.",
+    "Bold thinking from builders, reformers, and leaders pushing Canada to new frontiers.",
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.com"
   ),
@@ -26,7 +26,8 @@ export const metadata: Metadata = {
     type: "website",
     siteName: "Build Canada",
     title: "Build Canada",
-    description: "Canada's Voice for Builders.",
+    description:
+      "Bold thinking from builders, reformers, and leaders pushing Canada to new frontiers.",
   },
   twitter: {
     card: "summary_large_image",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -19,6 +19,9 @@ export const metadata: Metadata = {
   metadataBase: new URL(
     process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.com"
   ),
+  alternates: {
+    canonical: "/",
+  },
   openGraph: {
     type: "website",
     siteName: "Build Canada",

--- a/src/app/memos/[slug]/page.tsx
+++ b/src/app/memos/[slug]/page.tsx
@@ -42,6 +42,7 @@ export async function generateMetadata({
   return {
     title,
     description,
+    alternates: { canonical: `/memos/${slug}` },
     openGraph: {
       title,
       description,

--- a/src/app/memos/error.tsx
+++ b/src/app/memos/error.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+import { Button } from "@/components/ui/button";
+
+export default function MemosError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_TOKEN) {
+      posthog.captureException(error, {
+        digest: error.digest,
+        pathname: window.location.pathname,
+        boundary: "memos",
+      });
+    }
+  }, [error]);
+
+  return (
+    <div className="mx-[10px] my-[10px] border border-border-light bg-bg min-h-[60vh] flex flex-col items-center justify-center text-center px-5">
+      <span className="type-label text-accent mb-4 tracking-[0.2em]">
+        Memos
+      </span>
+      <h1
+        className="type-display-sm mb-4"
+        style={{ color: "var(--color-charcoal-1000)" }}
+      >
+        We couldn&apos;t load this.
+      </h1>
+      <p
+        className="type-body-sm mb-8 max-w-[420px]"
+        style={{ color: "var(--color-charcoal-600)" }}
+      >
+        Something went wrong while loading the memos. Try again, or browse from
+        the home page.
+      </p>
+      <div className="flex items-center gap-3">
+        <Button as="button" onClick={reset} variant="charcoal">
+          Try Again
+        </Button>
+        <Button as="link" href="/" variant="ghost">
+          Back to Home
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/memos/page.tsx
+++ b/src/app/memos/page.tsx
@@ -11,6 +11,7 @@ export const metadata: Metadata = {
   title: "Memos",
   description:
     "Bold thinking from Canada's builders, reformers, and leaders. Read policy memos and ideas worth building on.",
+  alternates: { canonical: "/memos" },
   openGraph: {
     title: "Memos",
     description:

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -7,9 +7,8 @@ export const contentType = "image/png";
 export default async function Image() {
   return new ImageResponse(
     <BuildCanadaOGImage
-      title="Canada's Voice for Builders"
+      title="Build Canada"
       description="Bold thinking from builders, reformers, and leaders pushing Canada to new frontiers."
-      label="Homepage"
     />,
     { ...size }
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -178,10 +178,12 @@ function SocialLinks() {
             />
           </a>
         ))}
-        <div className="w-px h-[18px] bg-border-light mx-0.5" />
-        <LinkButton href="/content" variant="primary">
-          Full Archive
-        </LinkButton>
+        {/* /content is being phased out — hide entry point until decision is finalized.
+            <div className="w-px h-[18px] bg-border-light mx-0.5" />
+            <LinkButton href="/content" variant="primary">
+              Full Archive
+            </LinkButton>
+        */}
       </div>
     </div>
   );

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -10,6 +10,7 @@ export const metadata: Metadata = {
   title: "Projects",
   description:
     "Transparent government data and better tools for pro-growth voices.",
+  alternates: { canonical: "/projects" },
   openGraph: {
     title: "Projects",
     description:

--- a/src/app/toronto/memos/[slug]/page.tsx
+++ b/src/app/toronto/memos/[slug]/page.tsx
@@ -48,6 +48,7 @@ export async function generateMetadata({
   return {
     title,
     description,
+    alternates: { canonical: `${BASE_PATH}/${slug}` },
     openGraph: {
       title,
       description,

--- a/src/app/toronto/memos/page.tsx
+++ b/src/app/toronto/memos/page.tsx
@@ -8,6 +8,7 @@ export const metadata: Metadata = {
   title: "Memos",
   description:
     "Bold thinking for Toronto. Read policy memos and ideas worth building on.",
+  alternates: { canonical: "/toronto/memos" },
   openGraph: {
     title: "🏗️ Toronto — Memos",
     description: "Bold thinking for Toronto.",

--- a/src/app/tracker/commitments/[id]/layout.tsx
+++ b/src/app/tracker/commitments/[id]/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Commitment - Outcomes Tracker - Build Canada",
+  description:
+    "Detailed status, sources, and assessments for a tracked federal commitment.",
+};
+
+export default function CommitmentDetailLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/tracker/commitments/layout.tsx
+++ b/src/app/tracker/commitments/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Commitments - Outcomes Tracker - Build Canada",
+  description:
+    "Browse and search every tracked commitment from Canada's federal government, with status and progress updates.",
+  alternates: { canonical: "/tracker/commitments" },
+};
+
+export default function CommitmentsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/tracker/commitments/page.tsx
+++ b/src/app/tracker/commitments/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useRef, useState } from "react";
+import { Suspense, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import useSWR from "swr";
 import { Search, ChevronUp, ChevronDown } from "lucide-react";
@@ -76,14 +76,14 @@ function CommitmentsPageInner() {
   const perPage = 50;
 
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const handleSearchChange = useCallback((value: string) => {
+  function handleSearchChange(value: string) {
     setSearch(value);
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       setDebouncedSearch(value);
       setPage(1);
     }, 300);
-  }, []);
+  }
 
   const qs = buildQueryString({
     q: debouncedSearch,

--- a/src/app/tracker/error.tsx
+++ b/src/app/tracker/error.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useEffect } from "react";
+import posthog from "posthog-js";
+
+export default function TrackerError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_POSTHOG_TOKEN) {
+      posthog.captureException(error, {
+        digest: error.digest,
+        pathname: window.location.pathname,
+        boundary: "tracker",
+      });
+    }
+  }, [error]);
+
+  return (
+    <div className="bg-white border border-[#cdc4bd] p-8 text-center">
+      <h2 className="text-2xl font-bold mb-3 text-gray-900">
+        We couldn&apos;t load tracker data.
+      </h2>
+      <p className="text-sm text-gray-600 mb-6 max-w-md mx-auto">
+        The tracker API didn&apos;t respond. This may be a temporary outage —
+        try again in a moment.
+      </p>
+      <button
+        onClick={reset}
+        className="px-4 py-2 text-sm bg-[#8b2332] text-white hover:opacity-90 transition-opacity"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/src/app/tracker/faq/page.tsx
+++ b/src/app/tracker/faq/page.tsx
@@ -4,6 +4,7 @@ export const metadata: Metadata = {
   title: "FAQ - Outcomes Tracker - Build Canada",
   description:
     "Frequently asked questions about the Build Canada Outcomes Tracker.",
+  alternates: { canonical: "/tracker/faq" },
 };
 
 const FAQS: { question: string; answer: React.ReactNode }[] = [

--- a/src/app/tracker/layout.tsx
+++ b/src/app/tracker/layout.tsx
@@ -8,6 +8,7 @@ const description = "Track the progress of Canada's government initiatives";
 export const metadata: Metadata = {
   title,
   description,
+  alternates: { canonical: "/tracker" },
   icons: {
     icon: "/tracker/buildcanada-logo-square.svg",
     apple: "/tracker/buildcanada-logo-square.svg",

--- a/src/app/tracker/ministries/[slug]/page.tsx
+++ b/src/app/tracker/ministries/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from "next";
 import Link from "next/link";
 import BurnUpChartWrapper from "@/components/tracker/BurnUpChartWrapper";
 import { fetchApi } from "@/lib/tracker-api";
@@ -6,6 +7,20 @@ import type {
   CommitmentsResponse,
   BurnUpResponse,
 } from "@/lib/commitment-types";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}): Promise<Metadata> {
+  const { slug } = await params;
+  const name = slug.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  return {
+    title: `${name} - Outcomes Tracker - Build Canada`,
+    description: `Tracked commitments and progress under ${name}.`,
+    alternates: { canonical: `/tracker/ministries/${slug}` },
+  };
+}
 
 const STATUS_LABELS: Record<string, string> = {
   not_started: "Not Started",

--- a/src/components/tracker/Sidebar.tsx
+++ b/src/components/tracker/Sidebar.tsx
@@ -44,13 +44,13 @@ function TrackerSubnav() {
 function SidebarLogo() {
   return (
     <div className="flex items-start gap-3 mb-8">
-      <a href="https://www.buildcanada.com" className="flex-shrink-0 mt-1">
+      <Link href="/" className="flex-shrink-0 mt-1">
         <img
           src="/tracker/buildcanada-logo-square.svg"
           alt="Build Canada"
           className="h-[4.5rem] w-[4.5rem]"
         />
-      </a>
+      </Link>
       <Link href="/tracker">
         <h1 className="text-4xl font-bold leading-none">
           Outcomes

--- a/src/components/tracker/ui/select.tsx
+++ b/src/components/tracker/ui/select.tsx
@@ -85,11 +85,15 @@ const SelectContent = React.forwardRef<
     >
       <SelectScrollUpButton />
       <SelectPrimitive.Viewport
-        className={cn(
-          "p-1",
-          position === "popper" &&
-            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]",
-        )}
+        className={cn("p-1", position === "popper" && "w-full")}
+        style={
+          position === "popper"
+            ? {
+                height: "var(--radix-select-trigger-height)",
+                minWidth: "var(--radix-select-trigger-width)",
+              }
+            : undefined
+        }
       >
         {children}
       </SelectPrimitive.Viewport>

--- a/src/lib/og-image-template.tsx
+++ b/src/lib/og-image-template.tsx
@@ -149,9 +149,7 @@ export function BuildCanadaOGImage({ title, description, badge, label }: OGImage
             {badge}
           </span>
         ) : (
-          <span style={{ fontSize: "24px", color: theme.foregroundFaint }}>
-            Canada&apos;s Voice for Builders
-          </span>
+          <span />
         )}
         <span style={{ fontSize: "22px", color: theme.foregroundFaint }}>
           buildcanada.com

--- a/src/lib/og-image-template.tsx
+++ b/src/lib/og-image-template.tsx
@@ -2,14 +2,14 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 
 const theme = {
-  background: "#1a1a1a",
+  background: "#f6ece3",
+  backgroundAlt: "#fbf6f1",
   accent: "#932f2f",
-  accentAlpha20: "rgba(147, 47, 47, 0.20)",
-  accentAlpha40: "rgba(147, 47, 47, 0.40)",
-  foreground: "#ffffff",
-  foreground80: "rgba(255, 255, 255, 0.80)",
-  foreground50: "rgba(255, 255, 255, 0.50)",
-  foreground30: "rgba(255, 255, 255, 0.30)",
+  accentSoft: "rgba(147, 47, 47, 0.20)",
+  foreground: "#272727",
+  foregroundMuted: "#5d5d5d",
+  foregroundFaint: "#888888",
+  border: "rgba(39, 39, 39, 0.18)",
 } as const;
 
 const sans = "system-ui, -apple-system, sans-serif";
@@ -31,7 +31,7 @@ export function BuildCanadaOGImage({ title, description, badge, label }: OGImage
         flexDirection: "column",
         backgroundColor: theme.background,
         color: theme.foreground,
-        padding: "100px 120px",
+        padding: "72px 96px",
         position: "relative",
         fontFamily: sans,
       }}
@@ -47,37 +47,73 @@ export function BuildCanadaOGImage({ title, description, badge, label }: OGImage
         }}
       />
 
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "60px" }}>
-        <div style={{ display: "flex", alignItems: "center", gap: "32px" }}>
-          <span style={{ fontSize: "36px", fontWeight: 800, letterSpacing: "3px", textTransform: "uppercase", color: theme.foreground }}>
-            BUILD CANADA
-          </span>
-          {label && (
-            <>
-              <div style={{ width: "8px", height: "8px", borderRadius: "50%", backgroundColor: theme.accent }} />
-              <span style={{ fontSize: "28px", textTransform: "uppercase", letterSpacing: "4px", color: theme.accentAlpha40 }}>
-                {label}
-              </span>
-            </>
-          )}
-        </div>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "24px",
+          marginBottom: "36px",
+        }}
+      >
+        <span
+          style={{
+            fontSize: "30px",
+            fontWeight: 800,
+            letterSpacing: "3px",
+            textTransform: "uppercase",
+            color: theme.foreground,
+          }}
+        >
+          BUILD CANADA
+        </span>
+        {label && (
+          <>
+            <div
+              style={{
+                width: "6px",
+                height: "6px",
+                borderRadius: "50%",
+                backgroundColor: theme.accent,
+              }}
+            />
+            <span
+              style={{
+                fontSize: "24px",
+                textTransform: "uppercase",
+                letterSpacing: "4px",
+                color: theme.accent,
+              }}
+            >
+              {label}
+            </span>
+          </>
+        )}
       </div>
 
-      <div style={{ width: "120px", height: "4px", backgroundColor: theme.accent, marginBottom: "60px" }} />
+      <div
+        style={{
+          width: "96px",
+          height: "3px",
+          backgroundColor: theme.accent,
+          marginBottom: "36px",
+        }}
+      />
 
-      <div style={{ display: "flex", flexDirection: "column", flex: 1 }}>
+      <div
+        style={{
+          display: "flex",
+          flexDirection: "column",
+          flex: 1,
+        }}
+      >
         <h1
           style={{
-            fontSize: "80px",
+            fontSize: "60px",
             lineHeight: 1.1,
             fontWeight: 700,
             color: theme.foreground,
+            letterSpacing: "-0.02em",
             margin: 0,
-            maxWidth: "1900px",
-            overflow: "hidden",
-            display: "-webkit-box",
-            WebkitLineClamp: 3,
-            WebkitBoxOrient: "vertical",
           }}
         >
           {title}
@@ -86,15 +122,11 @@ export function BuildCanadaOGImage({ title, description, badge, label }: OGImage
         {description && (
           <p
             style={{
-              fontSize: "36px",
-              color: theme.foreground80,
-              maxWidth: "1600px",
+              fontSize: "28px",
+              color: theme.foregroundMuted,
               lineHeight: 1.4,
-              marginTop: "40px",
-              overflow: "hidden",
-              display: "-webkit-box",
-              WebkitLineClamp: 2,
-              WebkitBoxOrient: "vertical",
+              marginTop: "24px",
+              marginBottom: 0,
             }}
           >
             {description}
@@ -102,13 +134,26 @@ export function BuildCanadaOGImage({ title, description, badge, label }: OGImage
         )}
       </div>
 
-      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: "auto", paddingTop: "60px" }}>
-        {badge && (
-          <span style={{ fontSize: "32px", color: theme.accent, fontWeight: 600 }}>
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          marginTop: "auto",
+          paddingTop: "32px",
+          borderTop: `1px solid ${theme.border}`,
+        }}
+      >
+        {badge ? (
+          <span style={{ fontSize: "24px", color: theme.accent, fontWeight: 600 }}>
             {badge}
           </span>
+        ) : (
+          <span style={{ fontSize: "24px", color: theme.foregroundFaint }}>
+            Canada&apos;s Voice for Builders
+          </span>
         )}
-        <span style={{ fontSize: "28px", color: theme.foreground30, marginLeft: "auto" }}>
+        <span style={{ fontSize: "22px", color: theme.foregroundFaint }}>
           buildcanada.com
         </span>
       </div>

--- a/src/lib/schemas/entities/organization.ts
+++ b/src/lib/schemas/entities/organization.ts
@@ -1,6 +1,6 @@
 import { Organization, WebSite } from "schema-dts";
 
-const SITE_URL = "https://buildcanada.com";
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || "https://buildcanada.com";
 
 export function createOrganization(): Organization {
   return {


### PR DESCRIPTION
- Add app-level error.tsx (modeled on not-found) plus memos/tracker section
  boundaries; all three report exceptions to PostHog with pathname + boundary
  context. Enable posthog-js capture_exceptions for unhandled client errors.
- Add metadata layouts for /tracker/commitments and /tracker/commitments/[id]
  (client components) and generateMetadata for /tracker/ministries/[slug] so
  every tracker route has a real title + description for tabs and sharing.
- Add /builders opengraph-image.tsx so the index has a social card.
- Add explicit alternates.canonical to root layout, memos/[slug],
  toronto/memos/[slug], builders, builders/[slug], projects, about,
  tracker (+ commitments/faq/ministry), and toronto/memos.
- Switch organization JSON-LD SITE_URL to read NEXT_PUBLIC_SITE_URL.
- Tracker Sidebar: replace hardcoded https://www.buildcanada.com link with
  internal Link to "/" so it works on any environment.
- Hide the homepage "Full Archive" button (links to /content, which is being
  phased out) by commenting it out.
- README: add Environment variables and Deployment notes sections covering
  required vars (NEXT_PUBLIC_SITE_URL, NEXT_PUBLIC_TRACKER_API_BASE,
  YORK_FACTORY_API_URL, LUMA_API_KEY) and recommended analytics vars.