### PR TITLE
Add memo engagement, Local Docker-Compose rig (frontend)

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,22 @@
+# syntax=docker/dockerfile:1.7
+# Dev image for local docker-compose. Source is bind-mounted at runtime;
+# node_modules lives in an anonymous volume so the container's deps win over
+# whatever (if anything) is in the host tree.
+
+FROM node:22.22.2-bookworm-slim
+
+ENV PNPM_HOME=/pnpm
+ENV PATH=$PNPM_HOME:$PATH
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN corepack enable && corepack prepare pnpm@9.5.0 --activate
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml ./
+RUN --mount=type=cache,id=pnpm,target=/pnpm/store \
+    pnpm install --frozen-lockfile --prefer-offline
+
+EXPOSE 5050
+
+CMD ["pnpm", "run", "dev"]

--- a/src/app/api/revalidate/route.ts
+++ b/src/app/api/revalidate/route.ts
@@ -1,0 +1,32 @@
+import { NextRequest, NextResponse } from "next/server";
+import { revalidateTag } from "next/cache";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+export async function POST(req: NextRequest) {
+  const secret = process.env.REVALIDATE_SECRET;
+  if (!secret) {
+    return NextResponse.json({ error: "revalidation_disabled" }, { status: 503 });
+  }
+
+  const auth = req.headers.get("authorization");
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 });
+  }
+
+  let body: { tag?: string; tags?: string[] };
+  try {
+    body = (await req.json()) as { tag?: string; tags?: string[] };
+  } catch {
+    return NextResponse.json({ error: "invalid_json" }, { status: 400 });
+  }
+
+  const tags = body.tags ?? (body.tag ? [body.tag] : []);
+  if (tags.length === 0) {
+    return NextResponse.json({ error: "no_tags" }, { status: 400 });
+  }
+
+  for (const tag of tags) revalidateTag(tag);
+  return NextResponse.json({ ok: true, revalidated: tags });
+}

--- a/src/app/memos/[slug]/MemoEngagement.tsx
+++ b/src/app/memos/[slug]/MemoEngagement.tsx
@@ -269,6 +269,27 @@ function EngagementDialog({
   // Reset state every time we open or change kind.
   useEffect(() => {
     if (!open) return;
+    // === SCREENSHOT BYPASS — REMOVE BEFORE COMMIT ===
+    // Skip the LinkedIn OAuth dance and prefill a mock verified identity so
+    // designers / docs can capture the post-auth modal state.
+    setPhase("ready");
+    setPayload({
+      sub: "mock-sub-123",
+      name: "Jane Doe",
+      given_name: "Jane",
+      family_name: "Doe",
+      email: "jane.doe@example.com",
+      email_verified: true,
+      picture: undefined,
+    });
+    setVerifiedTicket("mock-ticket");
+    setPostalCode("M5V 3A8");
+    setBody("");
+    setError(null);
+    setSubmitting(false);
+    return;
+    // === END SCREENSHOT BYPASS ===
+
     setPhase("connect");
     setPayload(null);
     setVerifiedTicket(null);
@@ -427,7 +448,7 @@ function EngagementDialog({
           <Dialog.Description className="type-body text-charcoal-600" style={{ marginBottom: "clamp(0.75rem, 2vw, 1.25rem)" }}>
             {kind === "endorsement"
               ? "Verify your identity through LinkedIn so your endorsement carries weight."
-              : "Verify your identity through LinkedIn and share your critique. Critiques are reviewed before they appear publicly."}
+              : "Verify your identity through LinkedIn and share your critique.  A critique must target the memo content in a constructive or positive way.  Anything self-promotional, including an ad hominen, or is deemed anyway unwelcome or hostile, will not be approved and may be removed."}
           </Dialog.Description>
 
           {phase === "connect" && (

--- a/src/app/memos/[slug]/MemoEngagement.tsx
+++ b/src/app/memos/[slug]/MemoEngagement.tsx
@@ -32,6 +32,28 @@ type Kind = "endorsement" | "critique";
 
 const POSTAL_CODE_REGEX = /^[A-Za-z]\d[A-Za-z] ?\d[A-Za-z]\d$/;
 
+// Remember the visitor's postal code between submissions so they don't retype
+// it for every endorsement/critique. Stored only in the browser — never in the DB.
+const POSTAL_CODE_STORAGE_KEY = "bc:engagement:postal-code";
+
+function readCachedPostalCode(): string {
+  if (typeof window === "undefined") return "";
+  try {
+    return window.localStorage.getItem(POSTAL_CODE_STORAGE_KEY) ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function writeCachedPostalCode(value: string) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(POSTAL_CODE_STORAGE_KEY, value);
+  } catch {
+    // Ignore private-mode / quota errors — caching is best-effort.
+  }
+}
+
 const TRUSTED_API_ORIGIN =
   process.env.NEXT_PUBLIC_YORK_FACTORY_ORIGIN || API_ORIGIN;
 
@@ -273,7 +295,7 @@ function EngagementDialog({
     setPhase("connect");
     setPayload(null);
     setVerifiedTicket(null);
-    setPostalCode("");
+    setPostalCode(readCachedPostalCode());
     setBody("");
     setError(null);
     setSubmitting(false);
@@ -383,6 +405,9 @@ function EngagementDialog({
         path,
         responseBody,
       );
+
+      // Remember the postal code for next time (browser-only, opt-out by clearing storage).
+      writeCachedPostalCode(postalCode);
 
       if (kind === "endorsement") {
         onEndorsed({ name: data.name, created_at: data.created_at });

--- a/src/app/memos/[slug]/MemoEngagement.tsx
+++ b/src/app/memos/[slug]/MemoEngagement.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { Dialog } from "@base-ui/react/dialog";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import { API_ORIGIN, API_URL, apiPost, type ApiPostError } from "@/lib/api/client";
+
+type Endorser = { name: string; created_at: string };
+type Critique = { id: number; name: string; body: string; created_at: string };
+
+interface Props {
+  memoSlug: string;
+  endorsementsCount: number;
+  critiquesCount: number;
+  recentEndorsers: Endorser[];
+  critiques: Critique[];
+}
+
+interface LinkedinPayload {
+  sub: string;
+  name: string;
+  given_name?: string;
+  family_name?: string;
+  email?: string;
+  email_verified?: boolean;
+  picture?: string;
+}
+
+type Kind = "endorsement" | "critique";
+
+const POSTAL_CODE_REGEX = /^[A-Za-z]\d[A-Za-z] ?\d[A-Za-z]\d$/;
+
+const TRUSTED_API_ORIGIN =
+  process.env.NEXT_PUBLIC_YORK_FACTORY_ORIGIN || API_ORIGIN;
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleDateString("en-CA", {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC",
+    });
+  } catch {
+    return "";
+  }
+}
+
+function splitFirstSentence(text: string): { first: string; rest: string } {
+  const trimmed = text.trim();
+  // Match characters up to and including the first sentence-ending punctuation
+  // followed by whitespace or end of string.
+  const match = trimmed.match(/^[\s\S]*?[.!?](?=\s|$)/);
+  if (!match) return { first: trimmed, rest: "" };
+  const first = match[0];
+  const rest = trimmed.slice(first.length).trim();
+  return { first: first.trim(), rest };
+}
+
+export function MemoEngagement(props: Props) {
+  const router = useRouter();
+  const [endorsementsCount, setEndorsementsCount] = useState(props.endorsementsCount);
+  const [critiquesCount, setCritiquesCount] = useState(props.critiquesCount);
+  const [recentEndorsers, setRecentEndorsers] = useState<Endorser[]>(props.recentEndorsers);
+  const [critiques, setCritiques] = useState<Critique[]>(props.critiques);
+  const [pendingCritique, setPendingCritique] = useState<Critique | null>(null);
+  const [openKind, setOpenKind] = useState<Kind | null>(null);
+
+  const handleEndorsed = (endorser: Endorser) => {
+    setEndorsementsCount((c) => c + 1);
+    setRecentEndorsers((list) => [endorser, ...list].slice(0, 5));
+    setOpenKind(null);
+    toast.success("Thanks for endorsing this memo.");
+    router.refresh();
+  };
+
+  const handleCritiqued = (critique: Critique) => {
+    setPendingCritique(critique);
+    setOpenKind(null);
+    toast.success("Critique submitted for review.");
+    router.refresh();
+  };
+
+  const handleDuplicate = (kind: Kind) => {
+    toast.error(
+      kind === "endorsement"
+        ? "You've already endorsed this memo."
+        : "You've already submitted a critique for this memo.",
+    );
+    setOpenKind(null);
+  };
+
+  return (
+    <section
+      data-testid="memo-engagement"
+      className="print-hide mt-12 pt-10 border-t border-border-light"
+    >
+      <div className="flex flex-wrap items-center gap-3 mb-6">
+        <Button
+          as="button"
+          variant="charcoal"
+          onClick={() => setOpenKind("endorsement")}
+        >
+          Endorse this memo
+        </Button>
+        <Button
+          as="button"
+          variant="ghost"
+          onClick={() => setOpenKind("critique")}
+        >
+          Critique this memo
+        </Button>
+        <span className="type-label text-text-secondary ml-auto">
+          {endorsementsCount} {endorsementsCount === 1 ? "endorsement" : "endorsements"}
+          {" · "}
+          {critiquesCount} {critiquesCount === 1 ? "critique" : "critiques"}
+        </span>
+      </div>
+
+      <div className="grid gap-8 md:grid-cols-2">
+        <div>
+          <h3 className="type-label mb-3">Recent endorsers</h3>
+          {recentEndorsers.length === 0 ? (
+            <p className="type-body text-text-secondary">
+              No endorsements yet. Be the first.
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {recentEndorsers.map((e, i) => (
+                <li
+                  key={`${e.name}-${e.created_at}-${i}`}
+                  className="type-body flex items-baseline justify-between gap-3"
+                >
+                  <span>{e.name}</span>
+                  <span className="type-label-sm text-text-secondary">
+                    {formatDate(e.created_at)}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        <div>
+          <h3 className="type-label mb-3">Critiques</h3>
+          {critiques.length === 0 && !pendingCritique ? (
+            <p className="type-body text-text-secondary">
+              No critiques yet.
+            </p>
+          ) : (
+            <ul className="space-y-5">
+              {pendingCritique && (
+                <CritiqueItem critique={pendingCritique} pending />
+              )}
+              {critiques.map((c) => (
+                <CritiqueItem key={c.id} critique={c} />
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+
+      <EngagementDialog
+        kind={openKind}
+        memoSlug={props.memoSlug}
+        onClose={() => setOpenKind(null)}
+        onEndorsed={handleEndorsed}
+        onCritiqued={handleCritiqued}
+        onDuplicate={handleDuplicate}
+      />
+    </section>
+  );
+}
+
+function CritiqueItem({ critique, pending = false }: { critique: Critique; pending?: boolean }) {
+  const [open, setOpen] = useState(false);
+  const { first, rest } = splitFirstSentence(critique.body);
+  const hasMore = rest.length > 0;
+
+  return (
+    <li className={`border-l-2 ${pending ? "border-yellow-500" : "border-border-light"} pl-4`}>
+      <div className="flex items-baseline justify-between gap-3 mb-1">
+        <span className="type-body font-medium">{critique.name}</span>
+        <span className={`type-label-sm ${pending ? "text-yellow-700" : "text-text-secondary"}`}>
+          {pending ? "Pending review" : formatDate(critique.created_at)}
+        </span>
+      </div>
+      <p className="type-body whitespace-pre-wrap">
+        {first}
+        {hasMore && (
+          <>
+            {" "}
+            <button
+              type="button"
+              onClick={() => setOpen(true)}
+              aria-label={`Read full critique by ${critique.name}`}
+              title="Read full critique"
+              className="inline-flex items-center justify-center w-5 h-5 align-text-bottom text-text-secondary hover:text-charcoal-1000 transition-colors cursor-pointer"
+            >
+              <svg width="12" height="12" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path d="M3 9v4h4M13 7V3H9M13 3l-5 5M3 13l5-5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+              </svg>
+            </button>
+          </>
+        )}
+      </p>
+
+      <Dialog.Root open={open} onOpenChange={setOpen}>
+        <Dialog.Portal>
+          <Dialog.Backdrop className="fixed inset-0 bg-black/50 z-[60]" />
+          <Dialog.Popup
+            className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-linen-100 border border-charcoal-300 w-[90vw] max-w-2xl z-[60] max-h-[85vh] overflow-y-auto"
+            style={{ padding: "clamp(1.5rem, 4vw, 2.5rem)" }}
+          >
+            <Dialog.Title className="type-title" style={{ marginBottom: "clamp(0.25rem, 1vw, 0.5rem)" }}>
+              {critique.name}
+            </Dialog.Title>
+            <Dialog.Description className="type-label-sm text-text-secondary" style={{ marginBottom: "clamp(0.75rem, 2vw, 1.25rem)" }}>
+              {pending ? "Pending review" : formatDate(critique.created_at)}
+            </Dialog.Description>
+            <p className="type-body whitespace-pre-wrap">{critique.body}</p>
+            <Dialog.Close
+              aria-label="Close dialog"
+              className="absolute w-11 h-11 flex items-center justify-center text-charcoal-600 hover:text-charcoal-1000 hover:bg-charcoal-200/30 rounded-sm transition-colors cursor-pointer"
+              style={{ top: "clamp(0.75rem, 2.5vw, 1.25rem)", right: "clamp(0.75rem, 2.5vw, 1.25rem)" }}
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+                <path d="M3 3l10 10M13 3L3 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+              </svg>
+            </Dialog.Close>
+          </Dialog.Popup>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </li>
+  );
+}
+
+interface DialogProps {
+  kind: Kind | null;
+  memoSlug: string;
+  onClose: () => void;
+  onEndorsed: (endorser: Endorser) => void;
+  onCritiqued: (critique: Critique) => void;
+  onDuplicate: (kind: Kind) => void;
+}
+
+function EngagementDialog({
+  kind,
+  memoSlug,
+  onClose,
+  onEndorsed,
+  onCritiqued,
+  onDuplicate,
+}: DialogProps) {
+  const [phase, setPhase] = useState<"connect" | "verifying" | "ready">("connect");
+  const [payload, setPayload] = useState<LinkedinPayload | null>(null);
+  const [verifiedTicket, setVerifiedTicket] = useState<string | null>(null);
+  const [postalCode, setPostalCode] = useState("");
+  const [body, setBody] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const popupRef = useRef<Window | null>(null);
+  const popupTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const open = kind !== null;
+
+  // Reset state every time we open or change kind.
+  useEffect(() => {
+    if (!open) return;
+    setPhase("connect");
+    setPayload(null);
+    setVerifiedTicket(null);
+    setPostalCode("");
+    setBody("");
+    setError(null);
+    setSubmitting(false);
+  }, [open, kind]);
+
+  // Listen for the popup's postMessage.
+  useEffect(() => {
+    if (!open) return;
+
+    const handler = (event: MessageEvent) => {
+      if (TRUSTED_API_ORIGIN && event.origin !== TRUSTED_API_ORIGIN) return;
+      const data = event.data as
+        | { type?: string; verifiedTicket?: string; payload?: LinkedinPayload; error?: string }
+        | null;
+      if (!data || data.type !== "linkedin-verified") return;
+
+      if (data.error) {
+        setError(`LinkedIn verification failed: ${data.error}`);
+        setPhase("connect");
+        return;
+      }
+      if (data.verifiedTicket && data.payload) {
+        setVerifiedTicket(data.verifiedTicket);
+        setPayload(data.payload);
+        setPhase("ready");
+      }
+    };
+
+    window.addEventListener("message", handler);
+    return () => window.removeEventListener("message", handler);
+  }, [open]);
+
+  // Clean up popup polling on close.
+  useEffect(() => {
+    if (open) return;
+    if (popupTimerRef.current) {
+      clearInterval(popupTimerRef.current);
+      popupTimerRef.current = null;
+    }
+    if (popupRef.current && !popupRef.current.closed) {
+      popupRef.current.close();
+    }
+    popupRef.current = null;
+  }, [open]);
+
+  const startLinkedin = () => {
+    if (!kind) return;
+    setError(null);
+    setPhase("verifying");
+
+    const startUrl = `${API_URL.replace(/\/api\/v1\/?$/, "")}/api/v1/auth/linkedin/start?kind=${kind}&memo_slug=${encodeURIComponent(memoSlug)}`;
+
+    const w = 600;
+    const h = 720;
+    const left = window.screenX + (window.outerWidth - w) / 2;
+    const top = window.screenY + (window.outerHeight - h) / 2;
+    const popup = window.open(
+      startUrl,
+      "linkedin-verify",
+      `width=${w},height=${h},left=${left},top=${top}`,
+    );
+
+    if (!popup) {
+      setError("Popup blocked. Please allow popups for this site and try again.");
+      setPhase("connect");
+      return;
+    }
+    popupRef.current = popup;
+
+    popupTimerRef.current = setInterval(() => {
+      if (popup.closed) {
+        if (popupTimerRef.current) {
+          clearInterval(popupTimerRef.current);
+          popupTimerRef.current = null;
+        }
+        // Only revert to connect if we never received the ticket.
+        setPhase((p) => (p === "verifying" ? "connect" : p));
+      }
+    }, 500);
+  };
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!kind || !verifiedTicket || !payload) return;
+
+    setError(null);
+
+    if (!POSTAL_CODE_REGEX.test(postalCode)) {
+      setError("Please enter a valid Canadian postal code (e.g. A1A 1A1).");
+      return;
+    }
+    if (kind === "critique" && body.trim().length < 5) {
+      setError("Please write a critique of at least 5 characters.");
+      return;
+    }
+
+    setSubmitting(true);
+    try {
+      const path = `/memos/${memoSlug}/${kind === "endorsement" ? "endorsements" : "critiques"}`;
+      const responseBody: Record<string, unknown> = {
+        verified_ticket: verifiedTicket,
+        postal_code: postalCode,
+      };
+      if (kind === "critique") responseBody.body = body.trim();
+
+      const data = await apiPost<{ id: number; name: string; body?: string; created_at: string }>(
+        path,
+        responseBody,
+      );
+
+      if (kind === "endorsement") {
+        onEndorsed({ name: data.name, created_at: data.created_at });
+      } else {
+        onCritiqued({
+          id: data.id,
+          name: data.name,
+          body: data.body ?? body.trim(),
+          created_at: data.created_at,
+        });
+      }
+    } catch (err) {
+      const apiErr = err as ApiPostError;
+      if (apiErr?.status === 409) {
+        onDuplicate(kind);
+        return;
+      }
+      const errBody = apiErr?.body as { errors?: string[]; message?: string } | undefined;
+      const message =
+        errBody?.errors?.join(", ") ||
+        errBody?.message ||
+        "Something went wrong. Please try again.";
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const inputClass =
+    "border border-charcoal-300 bg-white px-3 py-2.5 type-body placeholder:text-charcoal-400 outline-none focus:border-charcoal-1000 transition-colors w-full";
+
+  return (
+    <Dialog.Root open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="fixed inset-0 bg-black/50 z-[60]" />
+        <Dialog.Popup
+          className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-linen-100 border border-charcoal-300 w-[90vw] max-w-md z-[60] max-h-[90vh] overflow-y-auto"
+          style={{ padding: "clamp(1.5rem, 4vw, 2.5rem)" }}
+        >
+          <Dialog.Title className="type-title" style={{ marginBottom: "clamp(0.375rem, 1.5vw, 0.75rem)" }}>
+            {kind === "endorsement" ? "Endorse this memo" : "Critique this memo"}
+          </Dialog.Title>
+          <Dialog.Description className="type-body text-charcoal-600" style={{ marginBottom: "clamp(0.75rem, 2vw, 1.25rem)" }}>
+            {kind === "endorsement"
+              ? "Verify your identity through LinkedIn so your endorsement carries weight."
+              : "Verify your identity through LinkedIn and share your critique. Critiques are reviewed before they appear publicly."}
+          </Dialog.Description>
+
+          {phase === "connect" && (
+            <div className="flex flex-col gap-3">
+              <Button as="button" variant="charcoal" onClick={startLinkedin}>
+                Continue with LinkedIn
+              </Button>
+              {error && <p className="type-label-sm text-auburn-800">{error}</p>}
+            </div>
+          )}
+
+          {phase === "verifying" && (
+            <div className="flex flex-col gap-3">
+              <p className="type-body text-charcoal-600">
+                Waiting for LinkedIn… Complete the sign-in in the popup window.
+              </p>
+              <button
+                type="button"
+                onClick={() => setPhase("connect")}
+                className="type-label-sm text-charcoal-600 underline self-start cursor-pointer"
+              >
+                Cancel
+              </button>
+              {error && <p className="type-label-sm text-auburn-800">{error}</p>}
+            </div>
+          )}
+
+          {phase === "ready" && payload && (
+            <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+              <div className="border border-border-light bg-white p-3">
+                <p className="type-label-sm text-text-secondary mb-1">Verified via LinkedIn</p>
+                <p className="type-body font-medium">{payload.name}</p>
+                {payload.email && (
+                  <p className="type-label-sm text-text-secondary">
+                    {payload.email}
+                    {payload.email_verified && " (verified)"}
+                  </p>
+                )}
+              </div>
+
+              <input
+                type="text"
+                value={postalCode}
+                onChange={(e) => setPostalCode(e.target.value)}
+                placeholder="Postal code (e.g. A1A 1A1)"
+                required
+                maxLength={7}
+                className={inputClass}
+              />
+
+              {kind === "critique" && (
+                <textarea
+                  value={body}
+                  onChange={(e) => setBody(e.target.value)}
+                  placeholder="Write your critique…"
+                  required
+                  rows={6}
+                  maxLength={10000}
+                  className={`${inputClass} resize-vertical`}
+                />
+              )}
+
+              <Button as="button" type="submit" disabled={submitting} className="self-start">
+                {submitting ? "Submitting…" : kind === "endorsement" ? "Submit endorsement" : "Submit critique"}
+              </Button>
+
+              {error && <p className="type-label-sm text-auburn-800">{error}</p>}
+            </form>
+          )}
+
+          <Dialog.Close
+            aria-label="Close dialog"
+            className="absolute w-11 h-11 flex items-center justify-center text-charcoal-600 hover:text-charcoal-1000 hover:bg-charcoal-200/30 rounded-sm transition-colors cursor-pointer"
+            style={{ top: "clamp(0.75rem, 2.5vw, 1.25rem)", right: "clamp(0.75rem, 2.5vw, 1.25rem)" }}
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M3 3l10 10M13 3L3 13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </Dialog.Close>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/app/memos/[slug]/MemoEngagement.tsx
+++ b/src/app/memos/[slug]/MemoEngagement.tsx
@@ -269,26 +269,6 @@ function EngagementDialog({
   // Reset state every time we open or change kind.
   useEffect(() => {
     if (!open) return;
-    // === SCREENSHOT BYPASS — REMOVE BEFORE COMMIT ===
-    // Skip the LinkedIn OAuth dance and prefill a mock verified identity so
-    // designers / docs can capture the post-auth modal state.
-    setPhase("ready");
-    setPayload({
-      sub: "mock-sub-123",
-      name: "Jane Doe",
-      given_name: "Jane",
-      family_name: "Doe",
-      email: "jane.doe@example.com",
-      email_verified: true,
-      picture: undefined,
-    });
-    setVerifiedTicket("mock-ticket");
-    setPostalCode("M5V 3A8");
-    setBody("");
-    setError(null);
-    setSubmitting(false);
-    return;
-    // === END SCREENSHOT BYPASS ===
 
     setPhase("connect");
     setPayload(null);

--- a/src/app/memos/[slug]/page.tsx
+++ b/src/app/memos/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next";
 import { fetchMemo, fetchMemos, getSiteConfig } from "@/lib/api";
 import { extractHeadings } from "@/lib/extract-headings";
 import { TwitterEmbed, MemoSubscribe, RelatedMemos } from "./MemoClientParts";
+import { MemoEngagement } from "./MemoEngagement";
 import { ShareSection } from "@/components/share";
 import { MemoHero } from "./MemoHero";
 import { Signpost } from "@/components/custom/signpost";
@@ -219,6 +220,14 @@ export default async function MemoDetailPage({
           <div
             className="prose-bc"
             dangerouslySetInnerHTML={{ __html: bodyHtml }}
+          />
+
+          <MemoEngagement
+            memoSlug={memo.slug}
+            endorsementsCount={memo.endorsementsCount}
+            critiquesCount={memo.critiquesCount}
+            recentEndorsers={memo.recentEndorsers}
+            critiques={memo.critiques}
           />
 
           <div className="print-hide 2xl-memo:hidden mt-10 pt-8 border-t border-border-light">

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -2,9 +2,17 @@ export const API_URL =
   process.env.YORK_FACTORY_API_URL ||
   "https://yorkfactory.buildcanada.com/api/v1";
 
+export const API_ORIGIN = (() => {
+  try {
+    return new URL(API_URL).origin;
+  } catch {
+    return "";
+  }
+})();
+
 export async function apiFetch<T>(
   path: string,
-  options?: { revalidate?: number; params?: Record<string, string> },
+  options?: { revalidate?: number; params?: Record<string, string>; tags?: string[] },
 ): Promise<T> {
   const url = new URL(`${API_URL}${path}`);
   if (options?.params) {
@@ -15,13 +23,46 @@ export async function apiFetch<T>(
     }
   }
 
-  const res = await fetch(url.toString(), {
-    next: { revalidate: options?.revalidate ?? 60 },
-  });
+  const next: { revalidate: number; tags?: string[] } = {
+    revalidate: options?.revalidate ?? 60,
+  };
+  if (options?.tags && options.tags.length > 0) next.tags = options.tags;
+
+  const res = await fetch(url.toString(), { next });
 
   if (!res.ok) {
     throw new Error(`API error ${res.status}: ${path}`);
   }
 
   return res.json() as Promise<T>;
+}
+
+export interface ApiPostError extends Error {
+  status: number;
+  body: unknown;
+}
+
+export async function apiPost<T>(path: string, body: unknown): Promise<T> {
+  const res = await fetch(`${API_URL}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Accept: "application/json" },
+    body: JSON.stringify(body),
+    cache: "no-store",
+  });
+
+  let parsed: unknown = null;
+  try {
+    parsed = await res.json();
+  } catch {
+    // non-JSON body — leave parsed as null
+  }
+
+  if (!res.ok) {
+    const err = new Error(`API error ${res.status}: ${path}`) as ApiPostError;
+    err.status = res.status;
+    err.body = parsed;
+    throw err;
+  }
+
+  return parsed as T;
 }

--- a/src/lib/api/memos.ts
+++ b/src/lib/api/memos.ts
@@ -102,6 +102,7 @@ export async function fetchMemo(slug: string, params?: { publication?: string })
   const m = await apiFetch<YFMemoDetail>(`/memos/${slug}`, {
     revalidate: 300,
     params: queryParams,
+    tags: [`memo:${slug}`],
   });
   const keyMessages = extractKeyMessages((m.key_messages ?? []) as unknown[]);
   const authorName = m.author?.name ?? "Build Canada";
@@ -150,5 +151,26 @@ export async function fetchMemo(slug: string, params?: { publication?: string })
     publishedAt: m.published_at ?? null,
     createdAt: m.published_at ?? new Date().toISOString(),
     updatedAt: m.published_at ?? new Date().toISOString(),
+    endorsementsCount: m.endorsements_count ?? 0,
+    critiquesCount: m.critiques_count ?? 0,
+    recentEndorsers: m.recent_endorsers ?? [],
+    critiques: m.critiques ?? [],
+  };
+}
+
+export interface MemoEngagement {
+  endorsementsCount: number;
+  critiquesCount: number;
+  recentEndorsers: { name: string; created_at: string }[];
+  critiques: { id: number; name: string; body: string; created_at: string }[];
+}
+
+export async function fetchMemoEngagement(slug: string): Promise<MemoEngagement> {
+  const m = await apiFetch<YFMemoDetail>(`/memos/${slug}`, { revalidate: 0 });
+  return {
+    endorsementsCount: m.endorsements_count ?? 0,
+    critiquesCount: m.critiques_count ?? 0,
+    recentEndorsers: m.recent_endorsers ?? [],
+    critiques: m.critiques ?? [],
   };
 }

--- a/src/lib/api/types.ts
+++ b/src/lib/api/types.ts
@@ -33,6 +33,18 @@ export interface YFMemo {
   author: YFAuthor;
 }
 
+export interface YFMemoEndorser {
+  name: string;
+  created_at: string;
+}
+
+export interface YFMemoCritique {
+  id: number;
+  name: string;
+  body: string;
+  created_at: string;
+}
+
 export interface YFMemoDetail extends YFMemo {
   body: string;
   appendix: string | null;
@@ -42,6 +54,10 @@ export interface YFMemoDetail extends YFMemo {
   author_name: string | null;
   author_title: string | null;
   co_author: YFAuthor | null;
+  endorsements_count: number;
+  critiques_count: number;
+  recent_endorsers: YFMemoEndorser[];
+  critiques: YFMemoCritique[];
 }
 
 export interface YFTeamMember {


### PR DESCRIPTION
  # Memo engagement: Endorse + Critique buttons

  Adds an engagement section at the bottom of every memo page with **Endorse** and **Critique** buttons. Both modals route the user through a LinkedIn OIDC popup hosted by york_factory; on success the modal collects a Canadian postal code (and a critique body) and submits to the new york_factory endpoints. Counts and the 5 most recent endorsers/approved critiques render server-side; the user's own action is reflected immediately via
  optimistic update + on-demand cache revalidation.

  ## What's in this PR

  - **`MemoEngagement.tsx`** (new client island, `src/app/memos/[slug]/`) — buttons, dialog, popup-driven LinkedIn OAuth, postal-code validation, optimistic insert, `sonner` toasts. Critique bodies are cropped to the first sentence with a small expand-icon that opens the full body in a secondary modal — handles long critiques without dwarfing the page.
  - **`api/revalidate/route.ts`** (new) — Bearer-token-protected endpoint that calls `revalidateTag()`. Allows york_factory to bust the per-memo cache tag immediately when an endorsement is added or a critique is approved.
  - **`fetchMemo`** now tags its fetch with `memo:<slug>` so revalidation can target a single memo.
  - **`apiPost`** helper added to `src/lib/api/client.ts` (JSON, `cache: 'no-store'`, throws typed `ApiPostError` on non-2xx so the modal can branch on `409`).
  - **Type updates**: `YFMemoDetail` extended with `endorsements_count`, `critiques_count`, `recent_endorsers`, `critiques`. Mapped through `fetchMemo`.
  - **Hydration-safe date formatting** (`timeZone: "UTC"`) so SSR and client render identical strings.
  - Re-uses the existing `@base-ui/react/dialog` pattern from `SubscribeModal.tsx`. No new dependencies.

  ## New environment variables

  | Variable | Example | Purpose |
  |---|---|---|
  | `REVALIDATE_SECRET` | (secret) | Bearer token accepted by `/api/revalidate`. **Must match** york_factory's `NEXTJS_REVALIDATE_SECRET`. |
  | `NEXT_PUBLIC_YORK_FACTORY_ORIGIN` | `https://yorkfactory.buildcanada.com` | Trusted origin for `postMessage` from the LinkedIn callback popup. Optional — defaults to the origin parsed from `YORK_FACTORY_API_URL`, override only if the API is reverse-proxied under a different public origin. |

  Existing `YORK_FACTORY_API_URL` is unchanged.

  ## Required york_factory env vars (cross-repo)

  This PR depends on the corresponding york_factory PR being deployed and configured with:

  - `LINKEDIN_CLIENT_ID`
  - `LINKEDIN_CLIENT_SECRET`
  - `LINKEDIN_REDIRECT_URI` — must point to the york_factory `linkedin/callback` route
  - `LINKEDIN_POSTMESSAGE_ORIGIN` — must equal the production TradingPost origin (e.g. `https://buildcanada.com`)
  - `NEXTJS_REVALIDATE_URL` — must point to **this** app's `/api/revalidate`
  - `NEXTJS_REVALIDATE_SECRET` — must equal `REVALIDATE_SECRET` here

  LinkedIn app registration steps live in the york_factory PR.

  ## Deployment

  This PR can ship independently of york_factory but the engagement buttons will display zero counts until york_factory's migrations + endpoints are live. Recommended order:

  1. Merge & deploy the **york_factory** PR (run migrations).
  2. Set `REVALIDATE_SECRET` and `NEXT_PUBLIC_YORK_FACTORY_ORIGIN` (if needed) in Vercel project env.
  3. Set `NEXTJS_REVALIDATE_URL` and `NEXTJS_REVALIDATE_SECRET` in york_factory (Kamal secrets), then redeploy york_factory so the revalidator picks them up.
  4. Merge & deploy this PR.
  5. Open any memo page in production, smoke-test the flow (see below).

  ## Testing

  ### Local (against live york_factory dev)

  ```bash
  # in TradingPost
  cp .env.local.example .env.local   # if not present
  echo 'REVALIDATE_SECRET=dev-revalidate-secret' >> .env.local
  pnpm dev:remote
  ```

  Then in york_factory:

  ```bash
  # .env additions
  LINKEDIN_CLIENT_ID=...
  LINKEDIN_CLIENT_SECRET=...
  LINKEDIN_REDIRECT_URI=http://localhost:3000/api/v1/auth/linkedin/callback
  LINKEDIN_POSTMESSAGE_ORIGIN=http://localhost:5050
  NEXTJS_REVALIDATE_URL=http://localhost:5050/api/revalidate
  NEXTJS_REVALIDATE_SECRET=dev-revalidate-secret

  bin/rails s
  ```

  Open `http://localhost:5050/memos/<any-slug>` and walk through the steps below.

  ### Manual flow

  1. **Section renders** at the bottom of the memo, after the body, with current counts and "No endorsements yet" / "No critiques yet" if empty.
  2. **Endorse**: click → modal opens with "Continue with LinkedIn" → popup completes → modal swaps to read-only LinkedIn payload + postal-code field → submit `M5V 3A8` → toast "Thanks for endorsing this memo.", count increments, name appears at the top of the recent list.
  3. **Duplicate endorsement**: click Endorse again as the same LinkedIn user → toast "You've already endorsed this memo."
  4. **Critique**: click → fill body, submit → toast "Critique submitted for review.", optimistic row appears with yellow "Pending review" badge. Refresh the page — the pending row disappears (only approved critiques are public).
  5. **Admin approve** (in york_factory `/admin/critiques`) → approve the critique → within ~1s the TradingPost memo page, on next refresh, shows the critique without the pending badge. Verify `revalidateTag` fired by checking the TradingPost server logs for `POST /api/revalidate` with `200 { ok: true, revalidated: ["memo:<slug>"] }`.
  6. **Long critique**: critique with multiple sentences shows only the first sentence followed by a small expand icon. Click → modal opens with the full body, scrollable.
  7. **Invalid postal code**: enter `12345` → client-side error "Please enter a valid Canadian postal code (e.g. A1A 1A1).", no network call.
  8. **Popup blocked**: block popups in the browser → click Endorse → toast "Popup blocked. Please allow popups for this site and try again."
  9. **Wrong origin postMessage**: in DevTools console run `window.postMessage({type:"linkedin-verified", verifiedTicket:"x", payload:{}}, "*")` from a tab on a different origin (or simulate by editing `NEXT_PUBLIC_YORK_FACTORY_ORIGIN`) — the modal should ignore it.

  ### Build / lint

  ```bash
  pnpm lint
  pnpm build
  ```

  Should be clean. The new route lives under `src/app/api/revalidate/route.ts` and is opted out of static rendering (`dynamic = "force-dynamic"`).

  ### Cache-bust smoke test

  ```bash
  # Hit the endpoint directly to confirm it works:
  curl -i -X POST http://localhost:5050/api/revalidate \
    -H "Authorization: Bearer dev-revalidate-secret" \
    -H "Content-Type: application/json" \
    -d '{"tag":"memo:test-memo-title"}'

  # Expect: 200 { ok: true, revalidated: ["memo:test-memo-title"] }
  # Without the bearer: 401
  # With REVALIDATE_SECRET unset: 503
  ```

  ## Rollback

  `git revert <merge-commit>` and redeploy. The york_factory engagement endpoints can stay live — they're harmless without a frontend consumer. The `/api/revalidate` route disappearing means cache-bust calls from york_factory will start failing with `404`; logged as a warning by `NextjsRevalidator`, no impact on user-facing requests.

  ## Notes

  - The memo page remains statically generated via `generateStaticParams()`. The 5-minute ISR window (`revalidate: 300` in `fetchMemo`) is now made fresh on demand by tag-based revalidation when engagement changes — so users see new endorsements/critiques within seconds, not minutes.
  - The `fetchMemoEngagement` helper in `src/lib/api/memos.ts` is exported but currently unused; it's there for a future variant of the page that wants always-fresh counts at SSR time.

## Screenshots

At the bottom of the memo:

<img width="1026" height="660" alt="image" src="https://github.com/user-attachments/assets/52e8f8a4-de53-4a8e-91b0-6265220c7935" />

Note that critiques are cropped to the first sentence.

Expanded Critique (pop-out modal)

<img width="1287" height="529" alt="image" src="https://github.com/user-attachments/assets/7716b2fd-a4c4-4d78-b5ad-42bb674e2431" />

Endorse/Critique Modals

<img width="764" height="498" alt="image" src="https://github.com/user-attachments/assets/dba8a2c0-0780-47ed-bf82-a510a7c65329" />

<img width="759" height="592" alt="image" src="https://github.com/user-attachments/assets/99fa6906-f7ed-4ad2-8ab7-03e434426fa7" />

<img width="831" height="835" alt="image" src="https://github.com/user-attachments/assets/c5be27b7-195d-48f2-aa80-a7cf9139ec30" />

<img width="822" height="1287" alt="image" src="https://github.com/user-attachments/assets/dd762456-6289-401d-9d0b-a26aa61052ad" />


