### PR TITLE
cms: 308-redirect old slugs to canonical URL on detail pages

### DIFF
--- a/src/app/builders/[slug]/page.tsx
+++ b/src/app/builders/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
@@ -15,7 +15,7 @@ export async function generateMetadata({
     return {
       title: `${builder.name}: ${builder.tagline}`,
       description: builder.quote ?? undefined,
-      alternates: { canonical: `/builders/${slug}` },
+      alternates: { canonical: `/builders/${builder.slug}` },
       openGraph: {
         title: `${builder.name}: ${builder.tagline} | Build Canada`,
         description: builder.quote ?? undefined,
@@ -39,6 +39,10 @@ export default async function BuilderPage({
     builder = await fetchBuilder(slug);
   } catch {
     notFound();
+  }
+
+  if (builder.slug !== slug) {
+    permanentRedirect(`/builders/${builder.slug}`);
   }
 
   return (

--- a/src/app/memos/[slug]/page.tsx
+++ b/src/app/memos/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Image from "next/image";
 import { fetchMemo, fetchMemos, getSiteConfig } from "@/lib/api";
@@ -42,7 +42,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    alternates: { canonical: `/memos/${slug}` },
+    alternates: { canonical: `/memos/${memo.slug}` },
     openGraph: {
       title,
       description,
@@ -71,6 +71,10 @@ export default async function MemoDetailPage({
     memo = await fetchMemo(slug);
   } catch {
     notFound();
+  }
+
+  if (memo.slug !== slug) {
+    permanentRedirect(`/memos/${memo.slug}`);
   }
 
   const authorImage =

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Link from "next/link";
 import { fetchPost, fetchPosts, getSiteConfig } from "@/lib/api";
@@ -39,6 +39,7 @@ export async function generateMetadata({
   return {
     title,
     description,
+    alternates: { canonical: `/posts/${post.slug}` },
     openGraph: {
       title,
       description,
@@ -66,6 +67,10 @@ export default async function PostDetailPage({
     post = await fetchPost(slug);
   } catch {
     notFound();
+  }
+
+  if (post.slug !== slug) {
+    permanentRedirect(`/posts/${post.slug}`);
   }
 
   const date = new Date(post.publishedAt || post.createdAt).toLocaleDateString(

--- a/src/app/toronto/memos/[slug]/page.tsx
+++ b/src/app/toronto/memos/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation";
+import { notFound, permanentRedirect } from "next/navigation";
 import type { Metadata } from "next";
 import Image from "next/image";
 import { fetchMemo, fetchMemos, getSiteConfig } from "@/lib/api";
@@ -48,7 +48,7 @@ export async function generateMetadata({
   return {
     title,
     description,
-    alternates: { canonical: `${BASE_PATH}/${slug}` },
+    alternates: { canonical: `${BASE_PATH}/${memo.slug}` },
     openGraph: {
       title,
       description,
@@ -77,6 +77,10 @@ export default async function TorontoMemoDetailPage({
     memo = await fetchMemo(slug, { publication: PUBLICATION });
   } catch {
     notFound();
+  }
+
+  if (memo.slug !== slug) {
+    permanentRedirect(`${BASE_PATH}/${memo.slug}`);
   }
 
   const authorImage = memo.author.photo;


### PR DESCRIPTION
## Summary

york_factory [PR #43](https://github.com/BuildCanada/york_factory/pull/43) ships editable slugs with friendly_id's `:history` module preserved — old slugs continue to resolve to the current canonical record on the CMS side. This wires up the consumer site to honor that:

- On every slug-based detail page (`/memos/:slug`, `/toronto/memos/:slug`, `/posts/:slug`, `/builders/:slug`), compare the requested slug against `slug` returned by the API. If they differ, `permanentRedirect()` (HTTP 308) to the canonical URL.
- Point `alternates.canonical` at the canonical slug everywhere (was using the URL param), and add it to `/posts/:slug`, which was missing one.

The resulting flow when an editor renames `foo` → `bar`:
1. `/memos/foo` hits york_factory, friendly_id resolves via history, returns the record with `slug: "bar"`.
2. TradingPost sees the mismatch, returns 308 to `/memos/bar`.
3. Browser follows; `/memos/bar` returns 200 with `<link rel="canonical" href="/memos/bar">`.

## Why 308 and not 307

Permanent (308) is the right call here — transfers link equity to the new URL and gets search engines to update the index. The cache-staleness trade-off (browsers cache 308s) is real but self-healing: worst case is one extra round trip on a re-rename. Discussed inline; revisit with `Cache-Control: no-store` middleware if editors start churning slugs frequently.

## Test plan

- [ ] Rename a memo's slug in the york_factory admin; visit the OLD URL on TradingPost; confirm 308 → new URL in network tab.
- [ ] Repeat for a post, a builder, and a toronto memo.
- [ ] Visit the current canonical URL; confirm 200 (no redirect loop).
- [ ] Visit a never-existed slug; confirm 404 (not redirect).
- [ ] View source on a detail page; confirm `<link rel="canonical">` points at the canonical slug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)