### PR TITLE
docs: use pnpm in README setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,10 @@ Schema: [prisma/schema.prisma](prisma/schema.prisma)
 ## Setup
 
 ```bash
-npm install
-npx prisma generate
-npx prisma db push
-npm run dev
+pnpm install
+pnpm prisma generate
+pnpm prisma db push
+pnpm dev
 ```
 
 Requires a `.env` file with `DATABASE_URL` (defaults to `file:./dev.db`).


### PR DESCRIPTION
The README setup steps used npm, but the project uses pnpm (packageManager pnpm@9.5.0, plus mise.toml and pnpm-lock.yaml). Updated the setup block to pnpm so new contributors use the right toolchain and don't generate a stray package-lock.json.