### PR TITLE
Fix bill date hydration mismatch with UTC formatting

### DIFF
--- a/src/app/bills/components/BillCard.tsx
+++ b/src/app/bills/components/BillCard.tsx
@@ -3,10 +3,9 @@ import { memo, type ComponentProps } from "react";
 import { BillSummary } from "@/app/bills/types";
 import { Judgement, JudgementValue } from "./Judgement/judgement.component";
 import { DynamicIcon } from "lucide-react/dynamic";
-import dayjs from "dayjs";
-
 import { getCategoryIcon } from "@/app/bills/utils/bill-category-to-icon/bill-category-to-icon.util";
 import { getBillMostRecentDate } from "@/app/bills/utils/stages-to-dates/stages-to-dates";
+import { formatBillDate } from "@/app/bills/utils/format-date";
 import { TenetEvaluation } from "@/app/bills/models/Bill";
 import { BASE_PATH } from "@/app/bills/utils/basePath";
 
@@ -16,7 +15,7 @@ interface BillCardProps {
 
 function BillCard({ bill }: BillCardProps) {
   const bestDate = getBillMostRecentDate(bill);
-  const dateDisplay = bestDate ? dayjs(bestDate).format("MMM D, YYYY") : "N/A";
+  const dateDisplay = formatBillDate(bestDate);
 
   const judgementValue: JudgementValue = bill.final_judgment || "abstain";
 

--- a/src/app/bills/components/BillDetail/BillMetadata.tsx
+++ b/src/app/bills/components/BillDetail/BillMetadata.tsx
@@ -1,7 +1,7 @@
 import type { UnifiedBill } from "@/app/bills/utils/billConverters";
 import { Card, CardContent, CardHeader, CardTitle } from "../ui/card";
 import { getBillStageDates } from "@/app/bills/utils/stages-to-dates/stages-to-dates";
-import dayjs from "dayjs";
+import { formatBillDate } from "@/app/bills/utils/format-date";
 
 interface BillMetadataProps {
   bill: UnifiedBill;
@@ -18,9 +18,7 @@ const DataPoint = ({ label, value }: { label: string; value: string }) => {
 
 export function BillMetadata({ bill }: BillMetadataProps) {
   const billDates = getBillStageDates(bill.stages);
-  const lastUpdatedDate = billDates.lastUpdated
-    ? dayjs(billDates.lastUpdated).format("MMM D, YYYY")
-    : "N/A";
+  const lastUpdatedDate = formatBillDate(billDates.lastUpdated);
 
   return (
     <Card>

--- a/src/app/bills/utils/format-date.ts
+++ b/src/app/bills/utils/format-date.ts
@@ -1,0 +1,22 @@
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+
+/**
+ * Format a bill date as "MMM D, YYYY" in UTC.
+ *
+ * Bill stage dates are calendar dates stored as UTC midnight (e.g.
+ * "2025-06-05T00:00:00.000Z"). Formatting them in the runtime's local
+ * timezone makes SSR (UTC on the server) and hydration (the user's local
+ * timezone) disagree on the day, which triggers a React hydration mismatch.
+ * Formatting in UTC is deterministic across server and client AND preserves
+ * the intended calendar day.
+ */
+export function formatBillDate(
+  value?: Date | string | number | null,
+): string {
+  if (value === undefined || value === null) return "N/A";
+  const d = dayjs.utc(value);
+  return d.isValid() ? d.format("MMM D, YYYY") : "N/A";
+}


### PR DESCRIPTION
## Summary

Fixes a React hydration mismatch caused by bill date formatting.

Bill stage dates are calendar dates stored as UTC midnight (e.g. `2025-06-05T00:00:00.000Z`). Formatting them with `dayjs(...).format(...)` uses the runtime's local timezone, so the server (UTC) and client (user's local tz) could render different days — triggering a hydration mismatch.

## Changes

- Add `src/app/bills/utils/format-date.ts` with a shared `formatBillDate` helper that formats in UTC (`dayjs.utc`), deterministic across server and client, and handles null/invalid values by returning `"N/A"`.
- Use `formatBillDate` in `BillCard` and `BillMetadata`, removing the duplicated inline `dayjs` formatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)